### PR TITLE
Fix Card component props

### DIFF
--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,6 +1,6 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, HTMLAttributes } from 'react';
 
-interface CardProps {
+interface CardProps extends HTMLAttributes<HTMLDivElement> {
     children: ReactNode;
     className?: string;
 }
@@ -13,6 +13,6 @@ export function Card({ children, className = '', ...props }: CardProps) {
     );
 }
 
-export function CardContent({ children, ...props }: CardProps) {
-    return <div {...props}>{children}</div>;
+export function CardContent({ children, className = '', ...props }: CardProps) {
+    return <div className={className} {...props}>{children}</div>;
 }


### PR DESCRIPTION
## Summary
- extend Card and CardContent props to allow standard div attributes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68654b5027fc832d8575c171b0b0b775