### PR TITLE
Add basic auth pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import { AuthProvider } from "@/components/AuthProvider";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -16,7 +17,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <AuthProvider>{children}</AuthProvider>
+      </body>
     </html>
   );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useState, FormEvent } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/components/AuthProvider'
+
+export default function LoginPage() {
+  const [username, setUsername] = useState('')
+  const { login } = useAuth()
+  const router = useRouter()
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    if (!username) return
+    login(username)
+    router.push('/profile')
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <form onSubmit={handleSubmit} className="space-y-4 p-6 border rounded bg-white text-black">
+        <h1 className="text-xl font-bold">Login</h1>
+        <input
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="Username"
+          className="border p-2 rounded w-full"
+        />
+        <button type="submit" className="rounded px-4 py-2 bg-blue-500 text-white w-full">
+          Login
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/components/AuthProvider'
+
+export default function ProfilePage() {
+  const { user, logout } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!user) {
+      router.push('/login')
+    }
+  }, [user, router])
+
+  if (!user) return null
+
+  const handleLogout = () => {
+    logout()
+    router.push('/login')
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen space-y-4">
+      <h1 className="text-2xl font-bold">Welcome, {user.username}!</h1>
+      <button onClick={handleLogout} className="rounded px-4 py-2 bg-blue-500 text-white">
+        Logout
+      </button>
+    </div>
+  )
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useState, FormEvent } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/components/AuthProvider'
+
+export default function SignupPage() {
+  const [username, setUsername] = useState('')
+  const { signup } = useAuth()
+  const router = useRouter()
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    if (!username) return
+    signup(username)
+    router.push('/profile')
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <form onSubmit={handleSubmit} className="space-y-4 p-6 border rounded bg-white text-black">
+        <h1 className="text-xl font-bold">Sign Up</h1>
+        <input
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="Username"
+          className="border p-2 rounded w-full"
+        />
+        <button type="submit" className="rounded px-4 py-2 bg-blue-500 text-white w-full">
+          Sign Up
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+
+interface User {
+  username: string
+}
+
+interface AuthContextType {
+  user: User | null
+  login: (username: string) => void
+  signup: (username: string) => void
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+
+  useEffect(() => {
+    const stored = localStorage.getItem('user')
+    if (stored) setUser(JSON.parse(stored))
+  }, [])
+
+  const saveUser = (u: User | null) => {
+    setUser(u)
+    if (u) {
+      localStorage.setItem('user', JSON.stringify(u))
+    } else {
+      localStorage.removeItem('user')
+    }
+  }
+
+  const login = (username: string) => saveUser({ username })
+  const signup = (username: string) => saveUser({ username })
+  const logout = () => saveUser(null)
+
+  return (
+    <AuthContext.Provider value={{ user, login, signup, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (ctx === undefined) {
+    throw new Error('useAuth must be used within AuthProvider')
+  }
+  return ctx
+}


### PR DESCRIPTION
## Summary
- add AuthProvider to handle simple local user state
- create signup, login and profile pages
- wrap root layout with AuthProvider

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865620b3bdc832d89b63dcbb5a5089b