### PR TITLE
Fix build error with explicit OrbitControls path

### DIFF
--- a/components/NeuralAnimation.tsx
+++ b/components/NeuralAnimation.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react'
 import * as THREE from 'three'
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 
 export default function NeuralAnimation() {
   const containerRef = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
## Summary
- fix the OrbitControls import path in NeuralAnimation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686572fa7290832d9837f3844e53c49e