### PR TITLE
Fix WebGPURenderer import

### DIFF
--- a/components/AttractorParticles.tsx
+++ b/components/AttractorParticles.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react'
 import * as THREE from 'three'
+import WebGPURenderer from 'three/src/renderers/webgpu/WebGPURenderer.js'
 import {
   float,
   If,
@@ -32,7 +33,7 @@ export default function AttractorParticles() {
   useEffect(() => {
     let camera: THREE.PerspectiveCamera
     let scene: THREE.Scene
-    let renderer: THREE.WebGPURenderer
+    let renderer: WebGPURenderer
     let controls: OrbitControls
     let updateCompute: THREE.Compute
 
@@ -63,7 +64,7 @@ export default function AttractorParticles() {
       directionalLight.position.set(4, 2, 0)
       scene.add(directionalLight)
 
-      renderer = new THREE.WebGPURenderer({ antialias: true })
+      renderer = new WebGPURenderer({ antialias: true })
       renderer.setPixelRatio(window.devicePixelRatio)
       renderer.setSize(window.innerWidth, window.innerHeight)
       renderer.setAnimationLoop(animate)


### PR DESCRIPTION
## Summary
- fix WebGPURenderer import to use default export

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68657e87e83c832dbb63ff50dbf3ba53