### PR TITLE
Fix WebGPU renderer imports

### DIFF
--- a/components/AttractorParticles.tsx
+++ b/components/AttractorParticles.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
-import * as THREE from 'three'
+import * as THREE from 'three/webgpu'
 import {
   float,
   If,
@@ -34,7 +34,7 @@ export default function AttractorParticles() {
     let scene: THREE.Scene
     let renderer: THREE.WebGPURenderer
     let controls: OrbitControls
-    let updateCompute: THREE.Compute
+    let updateCompute: THREE.ComputeNode
 
     function onWindowResize() {
       if (!camera || !renderer) return


### PR DESCRIPTION
## Summary
- switch Three.js import to `three/webgpu`
- update compute type for WebGPU API

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68657f60147c832da85446d139c7a9d3