### PR TITLE
Fix Fn import usage error in AttractorParticles

### DIFF
--- a/components/AttractorParticles.tsx
+++ b/components/AttractorParticles.tsx
@@ -154,9 +154,13 @@ export default function AttractorParticles() {
       const positionBuffer = instancedArray(count, 'vec3')
       const velocityBuffer = instancedArray(count, 'vec3')
 
-      const sphericalToVec3 = Fn(([phi, theta]) => {
+      const sphericalToVec3 = Fn(([phi, theta], _builder) => {
         const sinPhiRadius = sin(phi)
-        return vec3(sinPhiRadius.mul(sin(theta)), cos(phi), sinPhiRadius.mul(cos(theta)))
+        return vec3(
+          sinPhiRadius.mul(sin(theta)),
+          cos(phi),
+          sinPhiRadius.mul(cos(theta)),
+        )
       })
 
       const init = Fn(() => {


### PR DESCRIPTION
## Summary
- resolve TypeScript error by passing the builder arg to `Fn`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686581df8324832db6997f5301fdccbf