### PR TITLE
Add animation under Explore button

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { BrainCircuit, Cloud, Zap, Menu } from "lucide-react";
+import AttractorsAnimation from "@/components/AttractorsAnimation";
 
 export default function Home() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -51,6 +52,7 @@ export default function Home() {
                 <button className="rounded px-6 py-3 text-lg mt-8 bg-white text-black hover:bg-gray-200 transition-colors">
                   Explore Our Technology
                 </button>
+                <AttractorsAnimation />
               </div>
             </div>
           </section>

--- a/components/AttractorsAnimation.tsx
+++ b/components/AttractorsAnimation.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+export default function AttractorsAnimation() {
+  return (
+    <iframe
+      src="/attractors.html"
+      className="w-full h-96 mt-8 border-0"
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- add `AttractorsAnimation` component for the animation iframe
- display `AttractorsAnimation` below the **Explore Our Technology** button on the homepage

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686585d22788832d9de5e2a1df147bb8