### PR TITLE
Improve attractor demo setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ## Getting Started
 
-First, run the development server:
+First, install the dependencies and run the development server:
 
 ```bash
+# install dependencies
+npm install
 npm run dev
 # or
 yarn dev
@@ -15,6 +17,8 @@ bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+To view the WebGPU attractors demo navigate to [http://localhost:3000/attractors](http://localhost:3000/attractors). This demo requires a WebGPU-enabled browser (for example, Chrome with the `--enable-dawn-features=compat` flag or an experimental build).
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 

--- a/public/attractors.html
+++ b/public/attractors.html
@@ -29,6 +29,12 @@
       import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
       import { TransformControls } from 'three/addons/controls/TransformControls.js';
 
+      if ( ! navigator.gpu ) {
+        const info = document.getElementById( 'info' );
+        if ( info ) info.textContent += ' - WebGPU not supported. Enable it in your browser.';
+        throw new Error( 'WebGPU not supported' );
+      }
+
       let camera, scene, renderer, controls, updateCompute;
 
       init();


### PR DESCRIPTION
## Summary
- clarify setup steps and demo location in README
- warn if WebGPU is unsupported in attractors demo

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865877807ec832d9bb2d06121090c3c