### PR TITLE
Add Threads background component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { BrainCircuit, Cloud, Zap, Menu } from "lucide-react";
+import Threads from "@/components/Threads";
 
 export default function Home() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -43,8 +44,14 @@ export default function Home() {
 
         <main className="flex-1 pt-20">
           <section className="relative overflow-hidden w-full py-24 md:py-32 lg:py-48">
-            <div className="relative z-10 container mx-auto px-4 md:px-6">
-              <div className="flex flex-col items-center space-y-4 text-center">
+            <div className="relative h-[350px] md:h-[500px] lg:h-[600px]">
+              <Threads
+                amplitude={5}
+                distance={0}
+                enableMouseInteraction
+                className="absolute inset-0"
+              />
+              <div className="relative z-10 flex flex-col items-center justify-center h-full container mx-auto px-4 md:px-6 text-center space-y-4">
                 <h1 className="text-4xl font-bold tracking-tighter sm:text-5xl md:text-6xl lg:text-7xl max-w-3xl mx-auto leading-tight">
                   Unleash the Power of Neural Data Cloud
                 </h1>

--- a/components/Threads.tsx
+++ b/components/Threads.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { Canvas, useFrame } from '@react-three/fiber'
+import { useRef } from 'react'
+import * as THREE from 'three'
+
+export interface ThreadsProps {
+  amplitude?: number
+  distance?: number
+  enableMouseInteraction?: boolean
+  className?: string
+}
+
+function ThreadLines({ amplitude = 1, distance = 5, enableMouseInteraction = false }: ThreadsProps) {
+  const group = useRef<THREE.Group>(null!)
+
+  // Create line geometries once
+  const lines = useRef<THREE.Line[]>([])
+
+  if (lines.current.length === 0) {
+    for (let i = 0; i < 50; i++) {
+      const material = new THREE.LineBasicMaterial({ color: '#06b6d4', transparent: true, opacity: 0.5 })
+      const points = new Float32Array([
+        (Math.random() - 0.5) * distance,
+        (Math.random() - 0.5) * distance,
+        (Math.random() - 0.5) * distance,
+        (Math.random() - 0.5) * distance,
+        (Math.random() - 0.5) * distance,
+        (Math.random() - 0.5) * distance,
+      ])
+      const geometry = new THREE.BufferGeometry()
+      geometry.setAttribute('position', new THREE.BufferAttribute(points, 3))
+      const line = new THREE.Line(geometry, material)
+      lines.current.push(line)
+    }
+  }
+
+  useFrame(({ clock, mouse }) => {
+    if (!group.current) return
+    const t = clock.getElapsedTime()
+    group.current.rotation.y = t * 0.1 * amplitude
+    if (enableMouseInteraction) {
+      group.current.rotation.x = mouse.y * amplitude * 0.5
+      group.current.rotation.z = mouse.x * amplitude * 0.5
+    }
+  })
+
+  return <group ref={group}>{lines.current.map((line, i) => <primitive key={i} object={line} />)}</group>
+}
+
+export default function Threads({ className, ...props }: ThreadsProps) {
+  return (
+    <Canvas className={className} camera={{ position: [0, 0, 10], fov: 50 }}>
+      <ambientLight intensity={0.5} />
+      <ThreadLines {...props} />
+    </Canvas>
+  )
+}


### PR DESCRIPTION
## Summary
- implement a new `Threads` component to render animated line segments
- show `Threads` in the home page hero section

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687308eb8f80832d83bb6529dc68c65d