### PR TITLE
fix: Remove Rob Franklin's name from README and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,9 +233,6 @@ When ready to implement the full monorepo:
 
 ### Leadership & Engineering Excellence
 
-**Rob Franklin** - _SVP, Brain Computer Interface_
-Blackrock Neurotech
-
 **Wael El Ghazzawi** - _CTO, Financial Technology_
 Brain Finance
 

--- a/instructions.md
+++ b/instructions.md
@@ -88,7 +88,7 @@ This document outlines the suggested user-facing content pages for the NeuraScal
 **Content:**
 
 - **Founders/Core Contributors:**
-  - Brief bios and roles: Rob Franklin, Wael El Ghazzawi, Ron Lehman, Donald Woodruff, Jason Franklin, Vincent Liu.
+  - Brief bios and roles: Wael El Ghazzawi, Ron Lehman, Donald Woodruff, Jason Franklin, Vincent Liu.
   - Highlight relevant experience in AI, neural interfaces, data science, scalable cloud infrastructure, and specific domains like XR, Neural-Prosthetics, etc.
 - **Mission/Values:**
   - A short statement about the team's shared passion for unlocking human potential and bridging technology gaps.


### PR DESCRIPTION
## Summary
This PR removes Rob Franklin's name from the README and documentation files as requested.

## Changes Made

### 1. README.md
- Removed Rob Franklin from the Team section
- Team now shows 5 members instead of 6

### 2. instructions.md
- Removed Rob Franklin from the founders/core contributors list

### 3. Git History
- Found one historical commit (2f581b28) that mentions "Add Rob Franklin's research papers to Whitepapers section"
- Other mentions of "rob" or "franklin" in git history are related to:
  - robot/robotics functionality
  - Jason Franklin (different person, kept in team list)

## Note on Git History
To completely remove Rob Franklin's name from git history would require rewriting repository history using:
- `git filter-branch` or
- BFG Repo-Cleaner

This is a destructive operation that changes all commit hashes and requires force-pushing. It should only be done if absolutely necessary, as it affects all forks and clones of the repository.

## Test Plan
- [x] Verify Rob Franklin's name is removed from README.md
- [x] Verify Rob Franklin's name is removed from instructions.md
- [x] Confirm Jason Franklin (different person) remains in the team list
- [x] Check that no other documentation files contain Rob Franklin's name

🤖 Generated with [Claude Code](https://claude.ai/code)