### PR TITLE
feat: Add dark mode toggle button to header

### DIFF
--- a/console/src/app/layout.tsx
+++ b/console/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/contexts/AuthContext";
+import { ThemeProvider } from "@/contexts/ThemeContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,7 +29,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <AuthProvider>{children}</AuthProvider>
+        <AuthProvider>
+          <ThemeProvider>{children}</ThemeProvider>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/console/src/components/layout/Header.tsx
+++ b/console/src/components/layout/Header.tsx
@@ -60,10 +60,19 @@ export default function Header({
       <div className="flex items-center space-x-3">
         <button
           onClick={onMenuClick}
-          className="p-1.5 hover:bg-gray-100 rounded-md transition-colors"
+          className="p-1.5 rounded-md transition-colors"
+          style={{
+            color: "var(--foreground)",
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = "rgba(59, 130, 246, 0.1)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = "transparent";
+          }}
         >
           <svg
-            className="h-5 w-5 text-gray-700"
+            className="h-5 w-5"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -80,19 +89,23 @@ export default function Header({
         <div className="flex items-center gap-3">
           <div className="flex items-center">
             <span className="font-extrabold text-lg tracking-wider">
-              <span className="text-black">NEURA</span>
+              <span style={{ color: "var(--foreground)" }}>NEURA</span>
               <span className="text-[#4185f4]">SCALE</span>
             </span>
           </div>
-          <div className="w-px h-6 bg-gray-300" />
+          <div
+            className="w-px h-6"
+            style={{ backgroundColor: "var(--foreground)", opacity: 0.3 }}
+          />
           <div className="flex items-center">
             {/* MIT Logo */}
             <svg
               className="h-5 w-auto"
               viewBox="0 0 536.229 536.229"
-              fill="black"
+              fill="currentColor"
               fillOpacity="1"
               xmlns="http://www.w3.org/2000/svg"
+              style={{ color: "var(--foreground)" }}
             >
               <g>
                 <g>
@@ -138,27 +151,55 @@ export default function Header({
             placeholder="Search (/)"
             value={searchValue}
             onChange={(e) => setSearchValue(e.target.value)}
-            className="w-full pl-10 pr-4 py-1.5 bg-gray-100 border border-gray-300 rounded-md focus:outline-none focus:bg-white focus:border-gray-400 transition-all duration-200 placeholder:text-gray-500 text-sm"
+            className="w-full pl-10 pr-4 py-1.5 rounded-md focus:outline-none transition-all duration-200 text-sm"
+            style={{
+              backgroundColor: "var(--card-bg)",
+              border: "1px solid var(--border)",
+              color: "var(--foreground)",
+            }}
+            onFocus={(e) => {
+              e.currentTarget.style.borderColor = "var(--primary)";
+            }}
+            onBlur={(e) => {
+              e.currentTarget.style.borderColor = "var(--border)";
+            }}
           />
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-500" />
+          <Search
+            className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4"
+            style={{ color: "var(--foreground)", opacity: 0.5 }}
+          />
         </div>
       </div>
 
       {/* Right section */}
       <div className="flex items-center space-x-1">
-        <button className="p-2 hover:bg-gray-100 rounded-full transition-colors">
-          <svg
-            className="h-5 w-5 text-gray-600"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-          >
+        <button
+          className="p-2 rounded-full transition-colors"
+          style={{ color: "var(--foreground)" }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = "rgba(59, 130, 246, 0.1)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = "transparent";
+          }}
+        >
+          <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
             <path d="M20 2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zM8 20H5c-.55 0-1-.45-1-1v-3h4v4zm0-6H4v-4h4v4zm0-6H4V5c0-.55.45-1 1-1h3v4zm6 12h-4v-4h4v4zm0-6h-4v-4h4v4zm0-6h-4V4h4v4zm6 12h-3c-.55 0-1-.45-1-1v-3h4v4zm0-6h-4v-4h4v4zm0-6h-4V4h3c.55 0 1 .45 1 1v3z" />
           </svg>
         </button>
 
-        <button className="p-2 hover:bg-gray-100 rounded-full transition-colors">
+        <button
+          className="p-2 rounded-full transition-colors"
+          style={{ color: "var(--foreground)" }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = "rgba(59, 130, 246, 0.1)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = "transparent";
+          }}
+        >
           <svg
-            className="h-5 w-5 text-gray-600"
+            className="h-5 w-5"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -172,8 +213,17 @@ export default function Header({
           </svg>
         </button>
 
-        <button className="p-2 hover:bg-gray-100 rounded-full transition-colors">
-          <SettingsIcon className="h-5 w-5 text-gray-600" />
+        <button
+          className="p-2 rounded-full transition-colors"
+          style={{ color: "var(--foreground)" }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = "rgba(59, 130, 246, 0.1)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = "transparent";
+          }}
+        >
+          <SettingsIcon className="h-5 w-5" />
         </button>
 
         {user ? (

--- a/console/src/components/layout/Header.tsx
+++ b/console/src/components/layout/Header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { Search, Menu, HelpCircle, User } from "lucide-react";
+import { Search, Menu, HelpCircle, User, Moon, Sun } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { useAuth } from "@/contexts/AuthContext";
+import { useTheme } from "@/contexts/ThemeContext";
 import { SettingsIcon } from "@/components/icons/GCPIcons";
 
 interface HeaderProps {
@@ -27,6 +28,7 @@ export default function Header({
   isSidebarHidden,
 }: HeaderProps) {
   const { user, signInWithGoogle, logout } = useAuth();
+  const { isDarkMode, toggleDarkMode } = useTheme();
   const [searchValue, setSearchValue] = useState("");
 
   const handleSignIn = async () => {
@@ -211,6 +213,25 @@ export default function Header({
               d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
             />
           </svg>
+        </button>
+
+        <button
+          className="p-2 rounded-full transition-colors"
+          style={{ color: "var(--foreground)" }}
+          onClick={toggleDarkMode}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = "rgba(59, 130, 246, 0.1)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = "transparent";
+          }}
+          title={isDarkMode ? "Switch to light mode" : "Switch to dark mode"}
+        >
+          {isDarkMode ? (
+            <Sun className="h-5 w-5" />
+          ) : (
+            <Moon className="h-5 w-5" />
+          )}
         </button>
 
         <button

--- a/console/src/contexts/ThemeContext.tsx
+++ b/console/src/contexts/ThemeContext.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+interface ThemeContextType {
+  isDarkMode: boolean;
+  toggleDarkMode: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [isDarkMode, setIsDarkMode] = useState(false);
+
+  useEffect(() => {
+    // Check if user has a saved preference
+    const savedTheme = localStorage.getItem("theme");
+    if (savedTheme) {
+      setIsDarkMode(savedTheme === "dark");
+    } else {
+      // Check system preference
+      const prefersDark = window.matchMedia(
+        "(prefers-color-scheme: dark)",
+      ).matches;
+      setIsDarkMode(prefersDark);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Apply or remove dark class on document element
+    if (isDarkMode) {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+    // Save preference
+    localStorage.setItem("theme", isDarkMode ? "dark" : "light");
+  }, [isDarkMode]);
+
+  const toggleDarkMode = () => {
+    setIsDarkMode(!isDarkMode);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ isDarkMode, toggleDarkMode }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
Added a manual dark mode toggle button to the header that allows users to switch between light and dark modes in the browser.

## Features
- **Theme Toggle Button**: Sun/moon icon button in the header
- **Theme Persistence**: User preference saved to localStorage
- **System Preference Detection**: Automatically detects system dark mode preference on first load
- **Smooth Transitions**: Seamless switching between light and dark modes

## Implementation Details
1. Created `ThemeContext` to manage theme state across the application
2. Added toggle button to Header component with appropriate icons:
   - Sun icon in dark mode (to switch to light)
   - Moon icon in light mode (to switch to dark)
3. Theme state is persisted in localStorage and restored on page load
4. Falls back to system preference if no saved preference exists

## Test plan
- [x] Test dark mode toggle button functionality
- [x] Verify theme persists after page refresh
- [x] Check all elements properly switch colors
- [x] Test on localhost:3000 in MCP browser
- [x] Verify icons and hover states work correctly

This allows testing dark/light mode functionality in any browser, including the MCP Playwright browser.

🤖 Generated with [Claude Code](https://claude.ai/code)