### PR TITLE
Connect billing dropdown to pricing page

### DIFF
--- a/console/src/components/layout/Header.tsx
+++ b/console/src/components/layout/Header.tsx
@@ -322,7 +322,7 @@ export default function Header({
                   />
                   <span>Settings</span>
                 </DropdownMenuItem>
-                <DropdownMenuItem>
+                <DropdownMenuItem onClick={() => router.push("/pricing")}>
                   <img
                     src="/svg/Billing.svg"
                     alt=""


### PR DESCRIPTION
## Summary
- Connects the billing dropdown menu item to navigate to the /pricing page
- Users can now click on "Billing" in the user menu to view subscription plans

## Changes
- Added onClick handler to billing DropdownMenuItem in Header.tsx
- Uses Next.js router to navigate to /pricing page

## Test Plan
1. Sign in to the console app
2. Click on your user avatar in the top right
3. Click on "Billing" in the dropdown menu
4. Verify it navigates to the pricing page showing subscription plans

🤖 Generated with [Claude Code](https://claude.ai/code)