### PR TITLE
Update Neon branch cleanup policy to delete immediately after merge

### DIFF
--- a/.github/scripts/cleanup-neon-branches.js
+++ b/.github/scripts/cleanup-neon-branches.js
@@ -6,7 +6,8 @@ const { execFileSync } = require("child_process");
 const NEON_PROJECT_ID = process.env.NEON_PROJECT_ID;
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY;
-const DAYS_TO_KEEP = parseInt(process.env.DAYS_TO_KEEP || "7", 10);
+// No longer keeping branches after merge - delete immediately
+// const DAYS_TO_KEEP = parseInt(process.env.DAYS_TO_KEEP || "7", 10);
 
 // Helper function to execute commands safely
 function exec(command, args = []) {
@@ -47,10 +48,9 @@ async function isPRMerged(prNumber) {
 }
 
 async function main() {
-  console.log(
-    `Starting cleanup of Neon branches older than ${DAYS_TO_KEEP} days...`,
-  );
+  console.log(`Starting cleanup of merged Neon branches...`);
   console.log(`Project ID: ${NEON_PROJECT_ID}`);
+  console.log(`Policy: Delete immediately after PR merge`);
 
   // Get all branches
   const branchesJson = exec("neonctl", [
@@ -68,11 +68,6 @@ async function main() {
 
   const branches = JSON.parse(branchesJson);
   console.log(`Found ${branches.length} total branches`);
-
-  // Calculate cutoff date
-  const cutoffDate = new Date();
-  cutoffDate.setDate(cutoffDate.getDate() - DAYS_TO_KEEP);
-  console.log(`Cutoff date: ${cutoffDate.toISOString()}`);
 
   let deletedCount = 0;
   let keptCount = 0;
@@ -112,17 +107,8 @@ async function main() {
       continue;
     }
 
-    // Check if branch is old enough to delete
-    if (branchDate >= cutoffDate) {
-      console.log(
-        `  ✅ PR #${prNumber} was merged but branch is recent, keeping for now`,
-      );
-      keptCount++;
-      continue;
-    }
-
-    // Delete the branch
-    console.log(`  🗑️  Deleting old merged PR branch...`);
+    // Delete the branch immediately since PR is merged
+    console.log(`  🗑️  PR #${prNumber} was merged, deleting branch...`);
     const deleteResult = exec("neonctl", [
       "branches",
       "delete",

--- a/.github/workflows/neon_cleanup.yml
+++ b/.github/workflows/neon_cleanup.yml
@@ -1,20 +1,14 @@
-name: Cleanup Old Neon Branches
+name: Cleanup Merged Neon Branches
 
 on:
   schedule:
     # Run every Sunday at 2 AM UTC
     - cron: '0 2 * * 0'
   workflow_dispatch:
-    inputs:
-      days_to_keep:
-        description: 'Number of days to keep merged PR branches'
-        required: false
-        default: '7'
-        type: number
 
 jobs:
-  cleanup_old_branches:
-    name: Cleanup Old Merged PR Branches
+  cleanup_merged_branches:
+    name: Cleanup Merged PR Branches
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -28,11 +22,10 @@ jobs:
       - name: Install neonctl
         run: npm install -g neonctl
 
-      - name: Cleanup old branches
+      - name: Cleanup merged branches
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
           NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          DAYS_TO_KEEP: ${{ inputs.days_to_keep || 7 }}
         run: node .github/scripts/cleanup-neon-branches.js

--- a/.github/workflows/neon_workflow.yml
+++ b/.github/workflows/neon_workflow.yml
@@ -82,11 +82,10 @@ jobs:
   delete_neon_branch:
     name: Delete Neon Branch
     needs: setup
-    # Only delete if PR is closed WITHOUT merging
+    # Delete branch when PR is closed (either merged or not)
     if: |
       github.event_name == 'pull_request' &&
-      github.event.action == 'closed' &&
-      github.event.pull_request.merged == false
+      github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
       - name: Delete Neon Branch


### PR DESCRIPTION
## Summary
Updated the Neon branch cleanup policy to delete branches immediately after PR merge instead of keeping them for 7 days.

## Changes

### 1. Updated cleanup script (`cleanup-neon-branches.js`)
- Removed the 7-day retention period logic
- Branches are now deleted immediately when PR is merged
- Updated console messages to reflect the new immediate deletion policy

### 2. Updated Neon workflow (`neon_workflow.yml`)
- Changed deletion condition from "closed WITHOUT merging" to "closed" (any reason)
- Now deletes branches when PRs are either merged or closed
- This ensures immediate cleanup after PR merge

### 3. Updated cleanup workflow (`neon_cleanup.yml`)
- Removed the `days_to_keep` input parameter
- Renamed workflow from "Cleanup Old Neon Branches" to "Cleanup Merged Neon Branches"
- Updated job name to reflect immediate deletion policy

## Rationale
This change prevents hitting Neon branch limits by cleaning up branches immediately after PR merge. Previously, branches were kept for 7 days which could lead to accumulation and hitting the branch limit (as we experienced earlier today).

## Testing
- Script syntax validated with `node -c`
- Workflow files validated
- The cleanup script will run on schedule or can be triggered manually

🤖 Generated with [Claude Code](https://claude.ai/code)