### PR TITLE
Hotfix: Fix Docker API module path

### DIFF
--- a/neural-engine/docker/Dockerfile.api
+++ b/neural-engine/docker/Dockerfile.api
@@ -38,4 +38,4 @@ ENV PORT=8080
 EXPOSE 8080
 
 # Run the API server
-CMD ["gunicorn", "--bind", ":8080", "--workers", "4", "--threads", "8", "--timeout", "0", "api.main:app"]
+CMD ["gunicorn", "--bind", ":8080", "--workers", "4", "--threads", "8", "--timeout", "0", "src.api.main:app"]


### PR DESCRIPTION
## Summary
- Fix incorrect module path in API Dockerfile
- Change from 'api.main:app' to 'src.api.main:app'

## Issue
The production deployment was failing because the Docker container couldn't find the API module. The gunicorn command was looking for 'api.main:app' but the correct path is 'src.api.main:app'.

## Test Plan
- [x] Verify module path matches actual code structure
- [ ] CI/CD pipeline should pass
- [ ] Docker build should complete successfully