### PR TITLE
fix: Re-enable Docker builds in CI/CD pipeline

### DIFF
--- a/.github/workflows/neural-engine-cicd.yml
+++ b/.github/workflows/neural-engine-cicd.yml
@@ -197,7 +197,7 @@ jobs:
   # Build Docker images only if tests pass
   build:
     needs: [setup, test]
-    if: success() && false  # Temporarily skip builds for Terraform-only fix
+    if: success()
     runs-on: self-hosted
     environment: ${{ needs.setup.outputs.environment }}
     permissions:
@@ -370,7 +370,7 @@ jobs:
 
   # Deploy infrastructure
   deploy:
-    needs: [setup, test, package-functions]  # Temporarily removed build dependency
+    needs: [setup, test, build, package-functions]
     if: |
       success() &&
       (github.event_name == 'push' ||


### PR DESCRIPTION
## Summary
- Re-enabled Docker builds that were temporarily disabled
- Restored build dependency in deploy job

## Context
Docker builds were temporarily disabled to quickly fix Terraform state issues in staging. Now that those issues are resolved, we need to re-enable the builds for proper deployment.

## Changes
- Removed `&& false` condition from build job
- Added back `build` dependency to deploy job