### PR TITLE
fix: Fix production deployment Terraform state issues

### DIFF
--- a/.github/workflows/neural-engine-cicd.yml
+++ b/.github/workflows/neural-engine-cicd.yml
@@ -410,11 +410,18 @@ jobs:
             -upgrade \
             -lock=false
 
-      - name: Import existing resources (staging only)
-        if: needs.setup.outputs.environment == 'staging'
+      - name: Import existing resources
+        if: needs.setup.outputs.environment == 'staging' || needs.setup.outputs.environment == 'production'
         working-directory: neural-engine/terraform
         run: |
-          # Remove and re-import resources that already exist in staging
+          # Determine the service account suffix based on environment
+          if [[ "${{ needs.setup.outputs.environment }}" == "production" ]]; then
+            SA_SUFFIX="prod"
+          else
+            SA_SUFFIX="stag"
+          fi
+
+          # Remove and re-import resources that already exist
           terraform state rm module.neural_ingestion.google_artifact_registry_repository.neural_engine || true
           terraform state rm module.neural_ingestion.google_service_account.ingestion || true
 
@@ -431,7 +438,7 @@ jobs:
             -var="project_id=${{ needs.setup.outputs.project_id }}" \
             -var="github_actions_service_account=github-actions@neurascale.iam.gserviceaccount.com" \
             module.neural_ingestion.google_service_account.ingestion \
-            "projects/${{ needs.setup.outputs.project_id }}/serviceAccounts/neural-ingestion-stag@${{ needs.setup.outputs.project_id }}.iam.gserviceaccount.com" || true
+            "projects/${{ needs.setup.outputs.project_id }}/serviceAccounts/neural-ingestion-${SA_SUFFIX}@${{ needs.setup.outputs.project_id }}.iam.gserviceaccount.com" || true
 
       - name: Terraform Plan and Apply
         working-directory: neural-engine/terraform

--- a/neural-engine/terraform/cost_optimization.tf
+++ b/neural-engine/terraform/cost_optimization.tf
@@ -13,7 +13,7 @@ resource "google_bigtable_app_profile" "autoscaling" {
   app_profile_id = "autoscaling-profile"
 
   single_cluster_routing {
-    cluster_id                 = "${module.neural_ingestion.bigtable_instance_id}-cluster"
+    cluster_id                 = "neural-data-cluster-${local.env_short}"
     allow_transactional_writes = false
   }
 }
@@ -30,7 +30,7 @@ resource "google_cloud_scheduler_job" "scale_down_dev" {
 
   http_target {
     http_method = "POST"
-    uri         = "https://bigtableadmin.googleapis.com/v2/projects/${var.project_id}/instances/${module.neural_ingestion.bigtable_instance_id}/clusters/${module.neural_ingestion.bigtable_instance_id}-cluster"
+    uri         = "https://bigtableadmin.googleapis.com/v2/projects/${var.project_id}/instances/${module.neural_ingestion.bigtable_instance_id}/clusters/neural-data-cluster-${local.env_short}"
 
     body = base64encode(jsonencode({
       serveNodes = var.bigtable_min_nodes_dev
@@ -54,7 +54,7 @@ resource "google_cloud_scheduler_job" "scale_up_dev" {
 
   http_target {
     http_method = "POST"
-    uri         = "https://bigtableadmin.googleapis.com/v2/projects/${var.project_id}/instances/${module.neural_ingestion.bigtable_instance_id}/clusters/${module.neural_ingestion.bigtable_instance_id}-cluster"
+    uri         = "https://bigtableadmin.googleapis.com/v2/projects/${var.project_id}/instances/${module.neural_ingestion.bigtable_instance_id}/clusters/neural-data-cluster-${local.env_short}"
 
     body = base64encode(jsonencode({
       serveNodes = var.bigtable_nodes_dev


### PR DESCRIPTION
## Summary
- Extended resource import logic to handle production environment
- Fixed Bigtable cluster ID references in cost optimization configuration
- Added dynamic service account suffix handling

## Problem
Production deployment was failing with:
1. Service account `neural-ingestion-prod` already exists (409 error)
2. Bigtable app profile referencing non-existent cluster ID

## Solution
1. Extended the import step to work for both staging and production
2. Fixed cluster ID construction to use `neural-data-cluster-prod` instead of `neural-data-production-cluster`
3. Added environment-based logic for service account suffixes (prod/stag)

## Testing
This will be tested when merged to main and the production deployment runs.