### PR TITLE
fix: Update Gemfile for Cayman theme on GitHub Pages

### DIFF
--- a/docs-site/Gemfile
+++ b/docs-site/Gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '~> 4.3.0'
-gem 'jekyll-theme-minimal'
+# Use GitHub Pages gem for compatibility
+gem 'github-pages', group: :jekyll_plugins
+gem 'jekyll-theme-cayman'
 
 # GitHub Pages plugins
 group :jekyll_plugins do

--- a/docs-site/_config.yml
+++ b/docs-site/_config.yml
@@ -6,6 +6,7 @@ url: "https://docs.neurascale.io" # the base hostname & protocol for your site
 
 # Theme settings
 theme: jekyll-theme-cayman
+remote_theme: pages-themes/cayman@v0.2.0
 # Alternative themes that work well for documentation:
 # theme: jekyll-theme-cayman
 # theme: jekyll-theme-slate


### PR DESCRIPTION
## Summary
Updates the Gemfile to properly load the Cayman theme on GitHub Pages.

## Changes
- Replace jekyll-theme-minimal with jekyll-theme-cayman in Gemfile  
- Add github-pages gem for better compatibility
- Add remote_theme configuration for GitHub Pages

## Why
The theme change in _config.yml wasn't being applied because the Gemfile still referenced the old theme. GitHub Pages needs both the Gemfile and _config.yml to be in sync.

This should fix the documentation site not showing the improved readability from the Cayman theme.