### PR TITLE
fix: Clean up orphaned Bigtable app profile blocking production deployment

### DIFF
--- a/.github/workflows/neural-engine-cicd.yml
+++ b/.github/workflows/neural-engine-cicd.yml
@@ -323,6 +323,23 @@ jobs:
           echo "Currently enabled APIs:"
           gcloud services list --enabled --project=${{ needs.setup.outputs.project_id }} | grep -E "bigquery|bigtable|compute|container|cloudfunctions|cloudrun|storage" || true
 
+      - name: Clean up Bigtable App Profiles
+        if: needs.setup.outputs.environment == 'production'
+        run: |
+          echo "Checking for orphaned Bigtable app profiles..."
+          # Check if the autoscaling-profile exists and delete it if found
+          if gcloud bigtable app-profiles describe autoscaling-profile \
+              --instance=neural-data-production \
+              --project=${{ needs.setup.outputs.project_id }} 2>/dev/null; then
+            echo "Found autoscaling-profile, attempting to delete..."
+            gcloud bigtable app-profiles delete autoscaling-profile \
+              --instance=neural-data-production \
+              --project=${{ needs.setup.outputs.project_id }} \
+              --force || echo "Failed to delete app profile, continuing..."
+          else
+            echo "No autoscaling-profile found, continuing..."
+          fi
+
       - name: Terraform Init
         working-directory: neural-engine/terraform
         timeout-minutes: 3


### PR DESCRIPTION
## Summary

This PR adds a cleanup step to remove an orphaned Bigtable app profile that's blocking production deployments.

## Problem

Production deployments are failing with:


The  exists in production but is not managed by Terraform, causing conflicts.

## Solution

Added a workflow step that:
1. Checks if the autoscaling-profile exists in production
2. Forcefully deletes it before Terraform runs
3. Allows Terraform to proceed without conflicts

## Testing

This approach allows the deployment to continue without modifying the Terraform state or configuration.

## Related Issues

Fixes the production deployment failures seen in run #16633448980