### PR TITLE
fix: Add --quiet flag to Bigtable app profile deletion command

### DIFF
--- a/.github/workflows/neural-engine-cicd.yml
+++ b/.github/workflows/neural-engine-cicd.yml
@@ -335,7 +335,7 @@ jobs:
             gcloud bigtable app-profiles delete autoscaling-profile \
               --instance=neural-data-production \
               --project=${{ needs.setup.outputs.project_id }} \
-              --force || echo "Failed to delete app profile, continuing..."
+              --force --quiet || echo "Failed to delete app profile, continuing..."
           else
             echo "No autoscaling-profile found, continuing..."
           fi


### PR DESCRIPTION
## Summary

Quick fix to resolve the interactive prompt issue when deleting Bigtable app profiles in CI/CD.

## Problem

The production deployment is failing because the gcloud command is prompting for confirmation:
```
ERROR: (gcloud.bigtable.app-profiles.delete) This prompt could not be answered because you are not in an interactive session.
```

## Solution

Added `--quiet` flag to the gcloud bigtable app-profiles delete command to accept default answers in non-interactive mode.

## Testing

This will allow the app profile deletion to proceed without user interaction in GitHub Actions.

## Related Issues

Fixes production deployment failures after PR #187