### PR TITLE
fix: Update Docker Build workflow to use Workload Identity Federation

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -62,13 +62,20 @@ jobs:
         with:
           install: true
 
-      - name: Log in to Google Container Registry
+      - name: Authenticate to Google Cloud
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: google-github-actions/auth@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: _json_key
-          password: ${{ secrets.GCP_SA_KEY }}
+          workload_identity_provider: 'projects/555656387124/locations/global/workloadIdentityPools/github-actions/providers/github'
+          service_account: 'github-actions@neurascale.iam.gserviceaccount.com'
+
+      - name: Set up Cloud SDK
+        if: github.event_name != 'pull_request'
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        if: github.event_name != 'pull_request'
+        run: gcloud auth configure-docker ${{ env.REGISTRY }}
 
       - name: Extract metadata
         id: meta
@@ -174,13 +181,20 @@ jobs:
         with:
           install: true
 
-      - name: Log in to Google Container Registry
+      - name: Authenticate to Google Cloud
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: google-github-actions/auth@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: _json_key
-          password: ${{ secrets.GCP_SA_KEY }}
+          workload_identity_provider: 'projects/555656387124/locations/global/workloadIdentityPools/github-actions/providers/github'
+          service_account: 'github-actions@neurascale.iam.gserviceaccount.com'
+
+      - name: Set up Cloud SDK
+        if: github.event_name != 'pull_request'
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        if: github.event_name != 'pull_request'
+        run: gcloud auth configure-docker ${{ env.REGISTRY }}
 
       - name: Extract metadata
         id: meta
@@ -211,6 +225,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- Replace deprecated service account key authentication with Workload Identity Federation
- Align Docker Build workflow with Neural Engine CI/CD authentication method
- Fix failing Docker builds due to missing GCP_SA_KEY secret

## Changes
- Replace `docker/login-action` with `google-github-actions/auth@v2` for WIF authentication
- Add `google-github-actions/setup-gcloud@v2` to set up Cloud SDK
- Configure Docker authentication using `gcloud auth configure-docker`
- Add `id-token: write` permission for OIDC token generation
- Remove dependency on `GCP_SA_KEY` secret

## Test plan
- [ ] Docker Build workflow runs successfully on this PR
- [ ] Images are pushed to GCR without authentication errors
- [ ] All build jobs complete successfully

🤖 Generated with [Claude Code](https://claude.ai/code)