### PR TITLE
fix: Complete WIF migration for build-base-images job

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -250,12 +250,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Google Container Registry
-        uses: docker/login-action@v3
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: _json_key
-          password: ${{ secrets.GCP_SA_KEY }}
+          workload_identity_provider: 'projects/555656387124/locations/global/workloadIdentityPools/github-actions/providers/github'
+          service_account: 'github-actions@neurascale.iam.gserviceaccount.com'
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.REGISTRY }}
 
       - name: Build and push base image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary
Complete the Workload Identity Federation migration by updating the build-base-images job that was missed in PR #190.

## Problem
The Docker Build workflow is still failing on main with:
```
Build Base Images (golang) - Error: Password required
```

This is because the build-base-images job is still using the old docker/login-action with GCP_SA_KEY.

## Solution
- Update build-base-images job to use google-github-actions/auth@v2
- Add google-github-actions/setup-gcloud@v2
- Configure Docker authentication with gcloud
- Remove dependency on GCP_SA_KEY secret

## Test plan
- [ ] Build base images job runs successfully
- [ ] All base images (python, golang, node, ml-base) are pushed to Artifact Registry
- [ ] No authentication errors

🤖 Generated with [Claude Code](https://claude.ai/code)