### PR TITLE
fix: Ensure user creation works in Docker base images

### DIFF
--- a/neural-engine/docker/dockerfiles/base/golang.Dockerfile
+++ b/neural-engine/docker/dockerfiles/base/golang.Dockerfile
@@ -19,9 +19,9 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest && \
     go install github.com/cosmtrek/air@latest && \
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
-# Create non-root user (check if group exists first)
-RUN addgroup -g 1000 neural 2>/dev/null || true && \
-    adduser -D -u 1000 -G neural neural 2>/dev/null || true
+# Create non-root user - ensure it's actually created
+RUN (getent group neural || addgroup -g 1000 neural) && \
+    (getent passwd neural || adduser -D -u 1000 -G neural neural)
 
 # Set up Go environment
 ENV GO111MODULE=on \

--- a/neural-engine/docker/dockerfiles/base/node.Dockerfile
+++ b/neural-engine/docker/dockerfiles/base/node.Dockerfile
@@ -20,9 +20,9 @@ RUN npm install -g \
     pm2@5.3.0 \
     pino-pretty@10.3.0
 
-# Create non-root user (check if group exists first)
-RUN addgroup -g 1000 neural 2>/dev/null || true && \
-    adduser -D -u 1000 -G neural neural 2>/dev/null || true
+# Create non-root user - ensure it's actually created
+RUN (getent group neural || addgroup -g 1000 neural) && \
+    (getent passwd neural || adduser -D -u 1000 -G neural neural)
 
 # Set npm configuration
 RUN npm config set update-notifier false && \


### PR DESCRIPTION
## Summary
- Fixes production Docker build failures caused by user creation issues
- Replaces 'adduser || true' pattern with proper getent checks
- Ensures user is actually created in all environments

## Problem
The previous approach using '|| true' was silently failing in some environments, causing subsequent chown commands to fail with 'unknown user/group neural:neural'.

## Solution
Use getent to check if user/group exists before creating them, ensuring they are actually created.

## Test plan
- [x] Updated node.Dockerfile and golang.Dockerfile
- [ ] CI builds should pass
- [ ] Production deployment should succeed

🤖 Generated with [Claude Code](https://claude.ai/code)