### PR TITLE
fix: Use higher GID/UID to avoid conflicts in Docker base images

### DIFF
--- a/neural-engine/README.md
+++ b/neural-engine/README.md
@@ -610,3 +610,5 @@ This project is licensed under the MIT License - see the [LICENSE](../LICENSE) f
 ---
 
 **Built with ❤️ and 🧠 by the NeuraScale Team**
+
+# Trigger CI

--- a/neural-engine/docker/dockerfiles/base/golang.Dockerfile
+++ b/neural-engine/docker/dockerfiles/base/golang.Dockerfile
@@ -19,9 +19,9 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest && \
     go install github.com/cosmtrek/air@latest && \
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
-# Create non-root user - ensure it's actually created
-RUN (getent group neural || addgroup -g 1000 neural) && \
-    (getent passwd neural || adduser -D -u 1000 -G neural neural)
+# Create non-root user with high GID/UID to avoid conflicts
+RUN addgroup -g 10001 neural && \
+    adduser -D -u 10001 -G neural neural
 
 # Set up Go environment
 ENV GO111MODULE=on \

--- a/neural-engine/docker/dockerfiles/base/golang.Dockerfile
+++ b/neural-engine/docker/dockerfiles/base/golang.Dockerfile
@@ -19,9 +19,9 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest && \
     go install github.com/cosmtrek/air@latest && \
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
-# Create non-root user (check if group exists first)
-RUN addgroup -g 1000 neural 2>/dev/null || true && \
-    adduser -D -u 1000 -G neural neural 2>/dev/null || true
+# Create non-root user - ensure it's actually created
+RUN (getent group neural || addgroup -g 1000 neural) && \
+    (getent passwd neural || adduser -D -u 1000 -G neural neural)
 
 # Set up Go environment
 ENV GO111MODULE=on \

--- a/neural-engine/docker/dockerfiles/base/node.Dockerfile
+++ b/neural-engine/docker/dockerfiles/base/node.Dockerfile
@@ -20,9 +20,9 @@ RUN npm install -g \
     pm2@5.3.0 \
     pino-pretty@10.3.0
 
-# Create non-root user - ensure it's actually created
-RUN (getent group neural || addgroup -g 1000 neural) && \
-    (getent passwd neural || adduser -D -u 1000 -G neural neural)
+# Create non-root user with high GID/UID to avoid conflicts
+RUN addgroup -g 10001 neural && \
+    adduser -D -u 10001 -G neural neural
 
 # Set npm configuration
 RUN npm config set update-notifier false && \

--- a/neural-engine/docker/dockerfiles/base/node.Dockerfile
+++ b/neural-engine/docker/dockerfiles/base/node.Dockerfile
@@ -20,9 +20,9 @@ RUN npm install -g \
     pm2@5.3.0 \
     pino-pretty@10.3.0
 
-# Create non-root user (check if group exists first)
-RUN addgroup -g 1000 neural 2>/dev/null || true && \
-    adduser -D -u 1000 -G neural neural 2>/dev/null || true
+# Create non-root user - ensure it's actually created
+RUN (getent group neural || addgroup -g 1000 neural) && \
+    (getent passwd neural || adduser -D -u 1000 -G neural neural)
 
 # Set npm configuration
 RUN npm config set update-notifier false && \


### PR DESCRIPTION
## Summary
- Fixes production Docker build failures caused by GID conflicts
- Changes from GID/UID 1000 to 10001 to avoid conflicts
- Node and Go base images often have existing users with GID/UID 1000

## Problem
The node:20-alpine base image already has a user with GID 1000, causing 'addgroup: gid 1000 in use' error.

## Solution
Use GID/UID 10001 which is unlikely to conflict with system users in base images.

## Test plan
- [x] Updated node.Dockerfile and golang.Dockerfile
- [ ] CI builds should pass
- [ ] Production deployment should succeed

🤖 Generated with [Claude Code](https://claude.ai/code)