### PR TITLE
fix: Handle existing GID/UID conflicts in Docker base images

### DIFF
--- a/neural-engine/docker/dockerfiles/base/golang.Dockerfile
+++ b/neural-engine/docker/dockerfiles/base/golang.Dockerfile
@@ -19,9 +19,17 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest && \
     go install github.com/cosmtrek/air@latest && \
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
-# Create non-root user - ensure it's actually created
-RUN (getent group neural || addgroup -g 1000 neural) && \
-    (getent passwd neural || adduser -D -u 1000 -G neural neural)
+# Create non-root user - handle conflicts with existing GID/UID
+RUN if getent group 1000 >/dev/null 2>&1; then \
+        addgroup -S neural; \
+    else \
+        addgroup -g 1000 neural; \
+    fi && \
+    if getent passwd 1000 >/dev/null 2>&1; then \
+        adduser -D -S -G neural neural; \
+    else \
+        adduser -D -u 1000 -G neural neural; \
+    fi
 
 # Set up Go environment
 ENV GO111MODULE=on \

--- a/neural-engine/docker/dockerfiles/base/node.Dockerfile
+++ b/neural-engine/docker/dockerfiles/base/node.Dockerfile
@@ -20,9 +20,17 @@ RUN npm install -g \
     pm2@5.3.0 \
     pino-pretty@10.3.0
 
-# Create non-root user - ensure it's actually created
-RUN (getent group neural || addgroup -g 1000 neural) && \
-    (getent passwd neural || adduser -D -u 1000 -G neural neural)
+# Create non-root user - handle conflicts with existing GID/UID
+RUN if getent group 1000 >/dev/null 2>&1; then \
+        addgroup -S neural; \
+    else \
+        addgroup -g 1000 neural; \
+    fi && \
+    if getent passwd 1000 >/dev/null 2>&1; then \
+        adduser -D -S -G neural neural; \
+    else \
+        adduser -D -u 1000 -G neural neural; \
+    fi
 
 # Set npm configuration
 RUN npm config set update-notifier false && \


### PR DESCRIPTION
## Summary
- Fixes production Docker build failures caused by GID/UID conflicts
- Checks if GID/UID 1000 is already in use before creating user
- Uses system-assigned GID/UID if 1000 is taken

## Problem
The node:20-alpine and golang:1.22-alpine base images have existing users with GID 1000, causing 'addgroup: gid 1000 in use' errors.

## Solution
Check if GID/UID 1000 is already taken and use system-assigned values if so.

## Test plan
- [x] Updated node.Dockerfile and golang.Dockerfile
- [ ] CI builds should pass
- [ ] Production deployment should succeed

🤖 Generated with [Claude Code](https://claude.ai/code)