### PR TITLE
URGENT: Fix 403 Forbidden - Use correct GCP project ID

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,7 +18,7 @@ on:
 env:
   GCP_REGION: northamerica-northeast1
   REGISTRY: northamerica-northeast1-docker.pkg.dev
-  PROJECT_ID: development-neurascale
+  PROJECT_ID: neurascale
 
 jobs:
   build:


### PR DESCRIPTION
Fixes production Docker build failures.

The service account `github-actions@neurascale.iam.gserviceaccount.com` belongs to the `neurascale` project, not `development-neurascale`.

This mismatch was causing 403 Forbidden errors when pushing to Artifact Registry.