### PR TITLE
URGENT: Fix production 403 errors - Add Artifact Registry permissions

### DIFF
--- a/FIX_PRODUCTION_NOW.sh
+++ b/FIX_PRODUCTION_NOW.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# EMERGENCY FIX FOR PRODUCTION 403 ERRORS
+
+echo "PRODUCTION IS BROKEN BECAUSE:"
+echo "- Service account: github-actions@neurascale.iam.gserviceaccount.com"
+echo "- Needs permission to push to: development-neurascale project"
+echo ""
+echo "RUN THIS COMMAND WITH GCLOUD AUTH:"
+echo ""
+echo "gcloud projects add-iam-policy-binding development-neurascale \\"
+echo "  --member='serviceAccount:github-actions@neurascale.iam.gserviceaccount.com' \\"
+echo "  --role='roles/artifactregistry.writer'"
+echo ""
+echo "This grants cross-project access for the service account to push images."

--- a/infrastructure/cross-project-iam/apply.sh
+++ b/infrastructure/cross-project-iam/apply.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Apply cross-project IAM permissions
+
+cd "$(dirname "$0")"
+
+echo "=== APPLYING CROSS-PROJECT IAM PERMISSIONS ==="
+echo ""
+echo "This will grant github-actions@neurascale.iam.gserviceaccount.com"
+echo "permissions to push to Artifact Registry in development-neurascale project"
+echo ""
+
+# Initialize Terraform
+terraform init
+
+# Plan the changes
+terraform plan -out=tfplan
+
+# Apply the changes
+terraform apply tfplan
+
+echo ""
+echo "Permissions have been applied. Production builds should now work."

--- a/infrastructure/cross-project-iam/main.tf
+++ b/infrastructure/cross-project-iam/main.tf
@@ -32,7 +32,8 @@ resource "google_project_service" "required_apis" {
       "iam.googleapis.com",
       "cloudresourcemanager.googleapis.com",
       "billingbudgets.googleapis.com",
-      "bigquery.googleapis.com"
+      "bigquery.googleapis.com",
+      "artifactregistry.googleapis.com"
     ]) : "${pair[0]}-${pair[1]}" => {
       project = pair[0]
       service = pair[1]
@@ -66,7 +67,8 @@ resource "google_project_iam_member" "github_actions_roles" {
       "roles/resourcemanager.projectIamAdmin",
       "roles/billing.costsManager",
       "roles/monitoring.admin",
-      "roles/logging.admin"
+      "roles/logging.admin",
+      "roles/artifactregistry.admin"
     ]) : "${pair[0]}-${pair[1]}" => {
       project = pair[0]
       role    = pair[1]
@@ -92,7 +94,8 @@ output "permissions_granted" {
       "roles/resourcemanager.projectIamAdmin",
       "roles/billing.costsManager",
       "roles/monitoring.admin",
-      "roles/logging.admin"
+      "roles/logging.admin",
+      "roles/artifactregistry.admin"
     ]
   }
 }

--- a/scripts/fix-artifact-registry-production.sh
+++ b/scripts/fix-artifact-registry-production.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Fix production Artifact Registry issues
+
+PROJECT_ID="development-neurascale"
+REGION="northamerica-northeast1"
+REPOSITORY="neural-engine-development"
+SERVICE_ACCOUNT="github-actions@neurascale.iam.gserviceaccount.com"
+
+echo "=== PRODUCTION FIX SCRIPT ==="
+echo ""
+echo "The problem: Service account from 'neurascale' project needs access to 'development-neurascale' project"
+echo ""
+echo "Run these commands:"
+echo ""
+echo "1. Grant Artifact Registry Writer role (allows push):"
+echo "gcloud projects add-iam-policy-binding $PROJECT_ID \\"
+echo "  --member='serviceAccount:$SERVICE_ACCOUNT' \\"
+echo "  --role='roles/artifactregistry.writer'"
+echo ""
+echo "2. If that doesn't work, also grant repository admin:"
+echo "gcloud artifacts repositories add-iam-policy-binding $REPOSITORY \\"
+echo "  --location=$REGION \\"
+echo "  --member='serviceAccount:$SERVICE_ACCOUNT' \\"
+echo "  --role='roles/artifactregistry.repoAdmin' \\"
+echo "  --project=$PROJECT_ID"
+echo ""
+echo "This will fix the 403 Forbidden errors immediately."


### PR DESCRIPTION
## IMMEDIATE FIX NEEDED FOR PRODUCTION

Production Docker builds are failing with 403 Forbidden errors.

## Root Cause
The GitHub Actions service account (github-actions@neurascale.iam.gserviceaccount.com) doesn't have Artifact Registry permissions in the development-neurascale project.

## Solution
1. Added artifactregistry.googleapis.com to enabled APIs
2. Added roles/artifactregistry.admin role to the service account

## Quick Fix (if Terraform can't be applied immediately)
Run this command:
```bash
gcloud projects add-iam-policy-binding development-neurascale \
  --member='serviceAccount:github-actions@neurascale.iam.gserviceaccount.com' \
  --role='roles/artifactregistry.writer'
```

## To Apply Terraform
```bash
cd infrastructure/cross-project-iam
./apply.sh
```