### PR TITLE
fix: Prevent KMS keyring destruction in production

### DIFF
--- a/neural-engine/terraform/environments/production.tfvars
+++ b/neural-engine/terraform/environments/production.tfvars
@@ -64,7 +64,7 @@ enable_storage_lifecycle_policies = true
 data_retention_days               = 2555 # 7 years for HIPAA compliance
 
 # Security configuration
-enable_enhanced_security    = false # Temporarily disabled - VPC service controls require access policy
+enable_enhanced_security    = true  # Keep security module to avoid destroying KMS resources
 enable_kms_encryption       = false # Temporarily disabled - KMS region incompatible with US storage
 enable_binary_authorization = false # Temporarily disabled - requires PEM key setup
 


### PR DESCRIPTION
## Summary
Fix production deployment error where Terraform tries to destroy KMS keyrings that have lifecycle protection.

## Problem
When we set `enable_enhanced_security = false`, Terraform tries to destroy the entire security module including KMS keyrings. These keyrings have `prevent_destroy = true` which blocks the deployment.

## Solution
Keep `enable_enhanced_security = true` to maintain the security module and existing KMS resources, while still keeping `enable_kms_encryption = false` to avoid using KMS for storage bucket encryption (due to region incompatibility).

## Test plan
- [ ] Production deployment should proceed without KMS destruction errors
- [ ] Existing KMS resources should remain intact
- [ ] Storage buckets should be created without KMS encryption

🤖 Generated with [Claude Code](https://claude.ai/code)