### PR TITLE
fix: Remove duplicate title from GitHub Pages documentation

### DIFF
--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -4,8 +4,6 @@ title: Home
 permalink: /
 ---
 
-# NeuraScale Documentation
-
 <div align="center">
 
 [![Neural Engine CI/CD](https://github.com/identity-wael/neurascale/actions/workflows/neural-engine-cicd.yml/badge.svg)](https://github.com/identity-wael/neurascale/actions/workflows/neural-engine-cicd.yml)


### PR DESCRIPTION
## Summary
- Fixed duplicate title display on docs.neurascale.io
- Removed the markdown heading that was conflicting with Jekyll theme's automatic title

## Changes
- Removed `# NeuraScale Documentation` from index.md
- Kept badges and welcome content properly formatted
- No deployment or code changes - documentation only

## Before
The page showed:
1. Jekyll theme title: "NeuraScale Documentation"
2. Raw markdown with duplicate title and badges

## After
- Clean display with single title from Jekyll theme
- Badges properly rendered
- No raw markdown visible

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>