### PR TITLE
Revert "fix: Remove duplicate title from GitHub Pages documentation"

### DIFF
--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -4,6 +4,8 @@ title: Home
 permalink: /
 ---
 
+# NeuraScale Documentation
+
 <div align="center">
 
 [![Neural Engine CI/CD](https://github.com/identity-wael/neurascale/actions/workflows/neural-engine-cicd.yml/badge.svg)](https://github.com/identity-wael/neurascale/actions/workflows/neural-engine-cicd.yml)


### PR DESCRIPTION
## Summary
This reverts commit 95421380 which removed the duplicate title from the documentation.

## Reason for Revert
The fix didn't work as expected. Restoring the previous state of the documentation.

## Changes
- Restores `# NeuraScale Documentation` heading to index.md
- Returns to the previous documentation structure

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>