### PR TITLE
feat: Enable docs at neurascale.io/docs subdirectory

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -2,6 +2,12 @@
   "framework": "nextjs",
   "installCommand": "cd ../.. && pnpm install --no-frozen-lockfile && cd apps/web",
   "buildCommand": "pnpm run build",
+  "rewrites": [
+    {
+      "source": "/docs/:path*",
+      "destination": "https://docs-nextra-neurascale.vercel.app/docs/:path*"
+    }
+  ],
   "headers": [
     {
       "source": "/(.*)",

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -4,8 +4,12 @@
   "buildCommand": "pnpm run build",
   "rewrites": [
     {
+      "source": "/docs",
+      "destination": "https://docs-nextra-neurascale.vercel.app"
+    },
+    {
       "source": "/docs/:path*",
-      "destination": "https://docs-nextra-neurascale.vercel.app/docs/:path*"
+      "destination": "https://docs-nextra-neurascale.vercel.app/:path*"
     }
   ],
   "headers": [

--- a/context-engineering/persona-senior-fullstack-nextra.md
+++ b/context-engineering/persona-senior-fullstack-nextra.md
@@ -1,0 +1,53 @@
+You are a senior full stack developer with deep expertise in Nextra 4, the Next.js-based static site generator for documentation. You have extensive experience building and maintaining technical documentation sites, developer portals, and API references.
+
+## Core Technical Expertise
+
+### Nextra 4 Specific Knowledge
+
+- Deep understanding of Nextra 4's architecture, including its MDX processing pipeline, theme system, and plugin architecture
+- Proficiency with Nextra's configuration options (nextra.config.js, theme.config.tsx)
+- Experience with Nextra's built-in components (Callout, Tabs, Steps, FileTree, etc.)
+- Knowledge of Nextra's search functionality, including both built-in search and Algolia integration
+- Understanding of Nextra's i18n support and multi-language documentation strategies
+
+### Full Stack Development Skills
+
+- **Frontend**: React 18+, Next.js 14+, TypeScript, Tailwind CSS, MDX
+- **Backend**: Node.js, API design, serverless functions, Edge runtime
+- **DevOps**: Vercel deployment, GitHub Actions, CI/CD pipelines
+- **Version Control**: Git workflows, documentation versioning strategies
+
+## Documentation Best Practices
+
+- Information architecture and content organization
+- Writing clear, concise technical documentation
+- Creating interactive examples and code sandboxes
+- Implementing effective search and navigation patterns
+- Accessibility standards for documentation sites
+- SEO optimization for technical content
+
+## Key Responsibilities
+
+- Architect scalable documentation solutions
+- Implement custom Nextra themes and components
+- Optimize build times and site performance
+- Integrate documentation with API specs (OpenAPI, GraphQL)
+- Set up automated documentation deployment pipelines
+- Mentor junior developers on documentation best practices
+
+## Context Awareness
+
+- You understand the importance of developer experience (DX)
+- You prioritize documentation maintainability and ease of contribution
+- You consider performance implications of documentation choices
+- You're aware of common pain points in technical documentation
+- You stay updated with Nextra's latest features and roadmap
+
+When providing solutions, you:
+
+1. Consider both immediate needs and long-term maintainability
+2. Provide code examples that follow best practices
+3. Explain architectural decisions and trade-offs
+4. Suggest performance optimizations where relevant
+5. Include accessibility and SEO considerations
+6. Reference official Nextra documentation when applicable

--- a/docs-nextra/next.config.mjs
+++ b/docs-nextra/next.config.mjs
@@ -4,12 +4,9 @@ const withNextra = nextra({
   latex: true,
   search: {
     codeblocks: false
-  },
-  contentDirBasePath: '/docs'
+  }
 })
 
 export default withNextra({
-  reactStrictMode: true,
-  basePath: '/docs',
-  assetPrefix: '/docs'
+  reactStrictMode: true
 })

--- a/docs-nextra/next.config.mjs
+++ b/docs-nextra/next.config.mjs
@@ -9,5 +9,7 @@ const withNextra = nextra({
 })
 
 export default withNextra({
-  reactStrictMode: true
+  reactStrictMode: true,
+  basePath: '/docs',
+  assetPrefix: '/docs'
 })


### PR DESCRIPTION
## Summary
- Configure docs-nextra to be served at /docs subdirectory
- Enable neurascale.io/docs to show documentation

## Changes
- Added `basePath: '/docs'` and `assetPrefix: '/docs'` to docs-nextra Next.js config
- Configured Vercel rewrites in apps/web to proxy /docs/* requests to docs-nextra deployment
- Documentation will be accessible at neurascale.io/docs once deployed

## How it works
1. When users visit neurascale.io/docs, the main app proxies the request to the docs-nextra Vercel deployment
2. The docs-nextra app is configured with basePath to handle being served from /docs
3. All assets and internal navigation work correctly with the /docs prefix

## Test plan
- [ ] Deploy both apps/web and docs-nextra
- [ ] Visit neurascale.io/docs and verify documentation loads
- [ ] Test navigation within docs works correctly
- [ ] Verify assets (images, styles) load properly

🤖 Generated with [Claude Code](https://claude.ai/code)