### PR TITLE
fix: use middleware proxy instead of redirects for /docs

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -2,6 +2,18 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 export function middleware(request: NextRequest) {
+  // Check if the request is for /docs
+  if (request.nextUrl.pathname.startsWith('/docs')) {
+    // Create the URL for the docs site
+    const docsUrl = new URL(
+      request.nextUrl.pathname.slice(5) + request.nextUrl.search,
+      'https://docs-nextra-neurascale.vercel.app'
+    );
+
+    // Return a rewrite to the docs site
+    return NextResponse.rewrite(docsUrl);
+  }
+
   // Create response
   const response = NextResponse.next();
 

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -2,16 +2,6 @@
   "framework": "nextjs",
   "installCommand": "cd ../.. && pnpm install --no-frozen-lockfile && cd apps/web",
   "buildCommand": "pnpm run build",
-  "rewrites": [
-    {
-      "source": "/docs",
-      "destination": "https://docs-nextra-neurascale.vercel.app"
-    },
-    {
-      "source": "/docs/:path*",
-      "destination": "https://docs-nextra-neurascale.vercel.app/:path*"
-    }
-  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- Fix the issue where neurascale.io/docs redirects to docs-nextra-neurascale.vercel.app
- Keep the URL as neurascale.io/docs when viewing documentation

## Problem
Vercel rewrites with external URLs cause redirects instead of proxying. This means users see the Vercel URL instead of staying on neurascale.io.

## Solution
Use Next.js middleware to proxy requests from /docs/* to the docs-nextra deployment. This keeps the URL in the browser as neurascale.io/docs.

## Changes
- Remove external rewrites from apps/web/vercel.json
- Add middleware logic to proxy /docs requests to docs-nextra
- Maintain all existing security headers for non-docs routes

## Test plan
- [ ] Deploy apps/web with these changes
- [ ] Visit neurascale.io/docs
- [ ] Verify URL stays as neurascale.io/docs (no redirect)
- [ ] Test navigation within docs works correctly
- [ ] Verify other routes still work normally

🤖 Generated with [Claude Code](https://claude.ai/code)