### PR TITLE
fix: use subdomain approach for docs instead of middleware proxy

### DIFF
--- a/apps/web/app/docs/route.ts
+++ b/apps/web/app/docs/route.ts
@@ -1,0 +1,7 @@
+import { redirect } from 'next/navigation';
+
+export function GET() {
+  // Redirect to docs subdomain
+  // Update this URL once docs.neurascale.io is configured
+  redirect('https://docs-nextra-neurascale.vercel.app');
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -2,18 +2,6 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 export function middleware(request: NextRequest) {
-  // Check if the request is for /docs
-  if (request.nextUrl.pathname.startsWith('/docs')) {
-    // Create the URL for the docs site
-    const docsUrl = new URL(
-      request.nextUrl.pathname.slice(5) + request.nextUrl.search,
-      'https://docs-nextra-neurascale.vercel.app'
-    );
-
-    // Return a rewrite to the docs site
-    return NextResponse.rewrite(docsUrl);
-  }
-
   // Create response
   const response = NextResponse.next();
 

--- a/docs/DOCS_SUBDOMAIN_SETUP.md
+++ b/docs/DOCS_SUBDOMAIN_SETUP.md
@@ -1,0 +1,47 @@
+# Documentation Subdomain Setup
+
+Since cross-origin rewrites don't work with Vercel (they trigger authentication), we need to use a subdomain approach.
+
+## Setup Instructions
+
+### 1. Add Custom Domain in Vercel
+
+1. Go to your docs-nextra project in Vercel
+2. Go to Settings → Domains
+3. Add `docs.neurascale.io`
+
+### 2. Configure DNS
+
+Add a CNAME record in your DNS provider:
+
+```
+Type: CNAME
+Name: docs
+Value: cname.vercel-dns.com
+TTL: 3600 (or your provider's default)
+```
+
+### 3. Wait for DNS Propagation
+
+DNS changes can take up to 48 hours to propagate, but usually complete within a few minutes.
+
+## Alternative: Redirect from /docs
+
+If you want neurascale.io/docs to redirect to docs.neurascale.io, add this to apps/web:
+
+```typescript
+// In app/docs/route.ts
+import { redirect } from "next/navigation";
+
+export function GET() {
+  redirect("https://docs.neurascale.io");
+}
+```
+
+## Benefits of Subdomain Approach
+
+- Clean separation between main site and docs
+- No authentication issues
+- Better performance (direct routing)
+- Easier to manage and deploy independently
+- Standard practice for documentation sites


### PR DESCRIPTION
## Summary
- Remove broken middleware proxy that triggers Vercel authentication
- Implement subdomain approach (docs.neurascale.io) as the proper solution
- Add temporary redirect from /docs to current Vercel URL

## Problem
The middleware approach to proxy external Vercel URLs doesn't work because:
1. Cross-origin rewrites trigger Vercel's authentication
2. This is a security feature and can't be bypassed
3. Users see Vercel login page instead of docs

## Solution
Use the standard approach: **subdomain (docs.neurascale.io)**

## Changes
1. Removed middleware proxy code that was causing auth issues
2. Added setup documentation for configuring docs.neurascale.io
3. Added route handler to redirect /docs to the docs site (temporary)

## Setup Required
1. In Vercel docs-nextra project settings, add domain: `docs.neurascale.io`
2. In DNS provider, add CNAME record:
   - Name: `docs`
   - Value: `cname.vercel-dns.com`
3. Once configured, update the redirect URL in `apps/web/app/docs/route.ts`

## Why Subdomain?
- Standard practice for documentation sites
- No authentication issues
- Better performance (direct routing)
- Clean separation of concerns
- Easier to manage independently

🤖 Generated with [Claude Code](https://claude.ai/code)