### PR TITLE
feat(docs-nextra): Migrate documentation to Nextra with professional content

### DIFF
--- a/docs-nextra/src/content/get-started.mdx
+++ b/docs-nextra/src/content/get-started.mdx
@@ -1,112 +1,265 @@
-import { Steps } from 'nextra/components'
+import { Steps, Tabs, Callout } from 'nextra/components'
 
 # Get Started
 
-## Quick start with Vercel
+This guide will help you get up and running with NeuraScale in minutes.
 
-You can start by creating your own Nextra site and deploying to Vercel by
-clicking the link:
+## Prerequisites
 
-[![](https://vercel.com/button)](https://vercel.com/new/clone?demo-description=Markdown%20powered%20docs%20site.%20Built%20with%20Next.js.&demo-image=https%3A%2F%2Fnextra.vercel.app%2Fdemo.png&demo-title=Documentation%20Starter%20Kit&demo-url=https%3A%2F%2Fnextra.vercel.app%2F&project-name=nextjs-docs&repository-name=nextjs-docs&s=https%3A%2F%2Fgithub.com%2Fshuding%2Fnextra&from=templates)
+Before you begin, ensure you have the following installed:
 
-Vercel will create the Nextra repository and deploy the site for you with just a
-few clicks. Once done, every change in the repository will be deployed
-automatically.
+- **Python** 3.12.11 (exact version required) - [Download](https://www.python.org/downloads/)
+- **Node.js** 18.x or higher - [Download](https://nodejs.org/)
+- **pnpm** 9.x or higher - [Installation guide](https://pnpm.io/installation)
+- **Docker** & Docker Compose - [Download](https://www.docker.com/)
+- **Git** - [Download](https://git-scm.com/)
 
-## Create manually
+<Callout type="warning">
+  Python version must be exactly 3.12.11. Other versions may cause compatibility issues.
+</Callout>
 
-Nextra works like a Next.js plugin, and it accepts a theme config (layout) to
-render the page. To start: [^3]
+## Quick Start
 
 <Steps>
-### Install Next.js, Nextra and React [^1]
+### Clone the Repository
 
-```sh npm2yarn
-npm i react react-dom next nextra
+```bash
+git clone https://github.com/identity-wael/neurascale.git
+cd neurascale
 ```
 
-### Install the docs theme [^2]
+### Set Up Virtual Environments
 
-```sh npm2yarn
-npm i nextra-theme-docs
+Run our automated setup script to configure Python environments:
+
+```bash
+./scripts/dev-tools/setup-venvs.sh
 ```
 
-### Create the following Next.js config and theme config under the root directory
+This script will:
+- Verify Python 3.12.11 is available
+- Create virtual environments for all components
+- Install required dependencies
 
-```js filename="next.config.mjs"
-import nextra from 'nextra'
+### Start Infrastructure Services
 
-const withNextra = nextra({
-  theme: 'nextra-theme-blog',
-  themeConfig: './theme.config.js'
-})
-export default withNextra()
+Launch the required infrastructure services:
+
+```bash
+docker-compose up -d
 ```
 
-### Create a `theme.config.js` file for the docs theme
+This starts:
+- TimescaleDB for time-series data
+- Redis for caching and real-time features
+- PostgreSQL for application data
 
-```js filename="theme.config.js"
-export default {
-  project: {
-    link: 'https://github.com/shuding/nextra' // GitHub link in the navbar
-  },
-  docsRepositoryBase: 'https://github.com/shuding/nextra/blob/master', // base URL for the docs repository
-  getNextSeoProps: () => ({ titleTemplate: '%s – Nextra' }),
-  navigation: true,
-  darkMode: true,
-  footer: {
-    text: `MIT ${new Date().getFullYear()} © Shu Ding.`
-  },
-  editLink: {
-    text: 'Edit this page on GitHub'
-  },
-  logo: (
-    <>
-      <svg>...</svg>
-      <span>Next.js Static Site Generator</span>
-    </>
-  ),
-  head: (
-    <>
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <meta name="description" content="Nextra: the next docs builder" />
-      <meta name="og:title" content="Nextra: the next docs builder" />
-    </>
-  ),
-  primaryHue: {
-    dark: 204,
-    light: 212
-  }
-}
+### Start the Neural Engine
+
+<Tabs items={['Development', 'Production']}>
+  <Tabs.Tab>
+    ```bash
+    cd neural-engine
+    source venv/bin/activate
+    python -m src.main
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```bash
+    cd neural-engine
+    source venv/bin/activate
+    uvicorn src.main:app --host 0.0.0.0 --port 8000 --workers 4
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+The Neural Engine API will be available at: http://localhost:8000
+
+### Start the Console (Optional)
+
+In a new terminal:
+
+```bash
+cd console
+npm run dev
 ```
 
-> [!NOTE]
->
-> More configuration options for the docs theme can be found
-> [here](/themes/docs/configuration).
+The NeuraScale Console will be available at: http://localhost:3000
 
-### You are good to go! Run `next dev` to start
+### Test Your Installation
 
+Create a synthetic device to verify everything is working:
+
+```bash
+# Create a test device
+curl -X POST http://localhost:8000/api/v1/devices \
+  -H "Content-Type: application/json" \
+  -d '{"device_id": "test-device", "device_type": "synthetic"}'
+
+# Start streaming data
+curl -X POST http://localhost:8000/api/v1/devices/test-device/stream/start
+```
+
+You should see synthetic neural data streaming in the logs.
 </Steps>
 
----
+## Project Structure
 
-<span id="sidebar-and-anchor-links" />
+```
+neurascale/
+├── neural-engine/           # Core neural data processing engine
+│   ├── src/
+│   │   ├── api/            # FastAPI endpoints
+│   │   ├── devices/        # Device interfaces (OpenBCI, Emotiv, etc.)
+│   │   ├── processing/     # Signal processing pipelines
+│   │   └── classification/ # Real-time ML models
+│   └── tests/              # Test suite
+├── console/                # NeuraScale Console UI
+├── docs-nextra/           # Documentation (you are here!)
+├── infrastructure/        # Terraform & Kubernetes configs
+└── scripts/              # Development tools and utilities
+```
 
-> [!NOTE]
->
-> Any `.md` or `.mdx` file will turn into a doc page and be displayed in
-> sidebar. You can also create a `_meta.js` file to customize the page order and
-> title. <br /> Check the source code: https://github.com/shuding/nextra for
-> more information.
+## Next Steps
 
-> [!TIP]
->
-> You can also use [`<style jsx>`](https://nextjs.org/docs/app/guides/css-in-js)
-> to style elements inside `theme.config.js`.
+Now that you have NeuraScale running, explore:
 
-[^1]: Install Next.js, Nextra and React.
+<div className="nx-grid nx-mt-6 nx-gap-4 md:nx-grid-cols-2">
+  <div className="nx-border nx-border-gray-200 dark:nx-border-gray-800 nx-rounded-lg nx-p-4">
+    <h3 className="nx-font-semibold nx-mb-2">Connect a Device</h3>
+    <p className="nx-text-sm nx-text-gray-600 dark:nx-text-gray-400 nx-mb-2">
+      Learn how to connect real BCI devices
+    </p>
+    <a href="/docs/device-integration" className="nx-text-primary-600 nx-text-sm">
+      Device Integration →
+    </a>
+  </div>
 
-[^2]: Install the docs theme.
+  <div className="nx-border nx-border-gray-200 dark:nx-border-gray-800 nx-rounded-lg nx-p-4">
+    <h3 className="nx-font-semibold nx-mb-2">Build Your First App</h3>
+    <p className="nx-text-sm nx-text-gray-600 dark:nx-text-gray-400 nx-mb-2">
+      Create a simple BCI application
+    </p>
+    <a href="/docs/tutorials/first-app" className="nx-text-primary-600 nx-text-sm">
+      Tutorial →
+    </a>
+  </div>
 
-[^3]: To start.
+  <div className="nx-border nx-border-gray-200 dark:nx-border-gray-800 nx-rounded-lg nx-p-4">
+    <h3 className="nx-font-semibold nx-mb-2">API Reference</h3>
+    <p className="nx-text-sm nx-text-gray-600 dark:nx-text-gray-400 nx-mb-2">
+      Explore the complete API documentation
+    </p>
+    <a href="/api-documentation" className="nx-text-primary-600 nx-text-sm">
+      API Docs →
+    </a>
+  </div>
+
+  <div className="nx-border nx-border-gray-200 dark:nx-border-gray-800 nx-rounded-lg nx-p-4">
+    <h3 className="nx-font-semibold nx-mb-2">Architecture Deep Dive</h3>
+    <p className="nx-text-sm nx-text-gray-600 dark:nx-text-gray-400 nx-mb-2">
+      Understand the system architecture
+    </p>
+    <a href="/architecture" className="nx-text-primary-600 nx-text-sm">
+      Architecture →
+    </a>
+  </div>
+</div>
+
+## Common Commands
+
+<Tabs items={['Neural Engine', 'Development', 'Docker']}>
+  <Tabs.Tab>
+    ```bash
+    # Activate virtual environment
+    source neural-engine/venv/bin/activate
+
+    # Start the engine
+    python -m src.main
+
+    # Run tests
+    pytest tests/
+
+    # Format code
+    black .
+
+    # Lint code
+    flake8 .
+
+    # Type checking
+    mypy .
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```bash
+    # Install dependencies
+    pnpm install
+
+    # Start development server
+    pnpm dev
+
+    # Build for production
+    pnpm build
+
+    # Run linting
+    pnpm lint
+
+    # Format code
+    pnpm format
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```bash
+    # Start all services
+    docker-compose up -d
+
+    # View logs
+    docker-compose logs -f
+
+    # Stop services
+    docker-compose down
+
+    # Clean volumes
+    docker-compose down -v
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+## Troubleshooting
+
+<Callout type="error" title="Port Already in Use">
+  If you see "Port 3000/8000 is already in use":
+
+  ```bash
+  # Find and kill the process
+  lsof -ti:3000 | xargs kill -9
+  # Or use a different port
+  PORT=3001 npm run dev
+  ```
+</Callout>
+
+<Callout type="error" title="Python Version Issues">
+  If you encounter Python version errors:
+
+  ```bash
+  # Check your Python version
+  python --version
+
+  # Must be exactly 3.12.11
+  # Run the setup script to fix
+  ./scripts/dev-tools/setup-venvs.sh
+  ```
+</Callout>
+
+<Callout type="info">
+  For more troubleshooting help, see our [Troubleshooting Guide](/docs/troubleshooting) or ask in [GitHub Discussions](https://github.com/identity-wael/neurascale/discussions).
+</Callout>
+
+## Getting Help
+
+- **Documentation**: [docs.neurascale.io](https://docs.neurascale.io)
+- **GitHub Discussions**: [Ask questions](https://github.com/identity-wael/neurascale/discussions)
+- **Issue Tracker**: [Report bugs](https://github.com/identity-wael/neurascale/issues)
+- **Email Support**: [support@neurascale.io](mailto:support@neurascale.io)
+
+Ready to build something amazing? Let's bridge mind and world together!

--- a/docs-nextra/src/content/index.mdx
+++ b/docs-nextra/src/content/index.mdx
@@ -1,4 +1,4 @@
-import { Table } from 'nextra/components'
+import { Table, Tabs } from 'nextra/components'
 
 # Introduction
 
@@ -235,54 +235,73 @@ graph TB
 
 ## Platform Status
 
-### Implementation Progress
+### Roadmap
 
-#### Completed Phases (Foundation & Integration)
+<Tabs items={['Completed', 'In Progress', 'Upcoming']} defaultIndex={0}>
+  <Tabs.Tab>
+    #### Foundation & Integration (Phases 1-8)
 
-- **Phase 1**: Core Infrastructure Setup
-- **Phase 2**: Data Models & Storage Layer
-- **Phase 3**: Basic Signal Processing Pipeline
-- **Phase 4**: User Management & Authentication
-- **Phase 5**: Device Interfaces & LSL Integration
-- **Phase 6**: Clinical Workflow Management
-- **Phase 7**: Advanced Signal Processing
-- **Phase 8**: Real-time Classification & Prediction
+    - **Phase 1**: Core Infrastructure Setup
+    - **Phase 2**: Data Models & Storage Layer
+    - **Phase 3**: Basic Signal Processing Pipeline
+    - **Phase 4**: User Management & Authentication
+    - **Phase 5**: Device Interfaces & LSL Integration
+    - **Phase 6**: Clinical Workflow Management
+    - **Phase 7**: Advanced Signal Processing
+    - **Phase 8**: Real-time Classification & Prediction
 
-#### Completed Phases (Intelligence)
+    #### Intelligence (Phases 9-12)
 
-- **Phase 9**: Performance Monitoring & Analytics
-- **Phase 10**: Security & Compliance Layer
-- **Phase 11**: NVIDIA Omniverse Integration
-- **Phase 12**: API Implementation & Enhancement
+    - **Phase 9**: Performance Monitoring & Analytics
+    - **Phase 10**: Security & Compliance Layer
+    - **Phase 11**: NVIDIA Omniverse Integration
+    - **Phase 12**: API Implementation & Enhancement
 
-#### Completed Phases (Infrastructure)
+    #### Infrastructure (Phases 13-15)
 
-- **Phase 13**: MCP Server Implementation
-- **Phase 14**: Terraform Infrastructure
-- **Phase 15**: Kubernetes Deployment (Current)
+    - **Phase 13**: MCP Server Implementation
+    - **Phase 14**: Terraform Infrastructure
+    - **Phase 15**: Kubernetes Deployment
+  </Tabs.Tab>
 
-#### In Progress
+  <Tabs.Tab>
+    #### Phase 16: Docker Containerization Enhancement
 
-- **Phase 16**: Docker Containerization Enhancement (Q1 2025)
-  - Multi-stage optimized builds
-  - Security hardening
-  - Registry management
+    **Timeline**: Q1 2025
 
-#### Upcoming
+    - Multi-stage optimized builds
+    - Security hardening with minimal base images
+    - Container registry management
+    - Vulnerability scanning integration
+    - Size optimization strategies
+  </Tabs.Tab>
 
-- **Phase 17**: CI/CD Pipeline (Q1 2025)
-  - GitHub Actions workflows
-  - GitLab CI integration
-  - ArgoCD for GitOps
+  <Tabs.Tab>
+    #### Phase 17: CI/CD Pipeline (Q1 2025)
 
-- **Phase 18-20**: Quality Assurance (Q2 2025)
-  - Unit Testing Suite
-  - Integration Testing
-  - Performance Testing
+    - GitHub Actions workflows
+    - GitLab CI integration
+    - ArgoCD for GitOps
+    - Automated testing pipelines
+    - Multi-environment deployments
 
-- **Phase 21-22**: Delivery (Q3 2025)
-  - Documentation & Training
-  - Full System Integration Test
+    #### Phases 18-20: Quality Assurance (Q2 2025)
+
+    - Comprehensive Unit Testing Suite
+    - Integration Testing Framework
+    - Performance Testing & Benchmarks
+    - Load Testing Infrastructure
+    - Security Testing Suite
+
+    #### Phases 21-22: Delivery (Q3 2025)
+
+    - Complete Documentation & Training Materials
+    - Full System Integration Testing
+    - Production Readiness Review
+    - Launch Preparation
+    - Post-Launch Support Plan
+  </Tabs.Tab>
+</Tabs>
 
 ## Quick Start
 

--- a/docs-nextra/src/content/index.mdx
+++ b/docs-nextra/src/content/index.mdx
@@ -4,50 +4,6 @@ import { Table, Tabs } from 'nextra/components'
 
 Welcome to the official documentation for **NeuraScale**, a comprehensive Brain-Computer Interface (BCI) platform providing real-time neural data acquisition, processing, and analysis with sub-100ms latency.
 
-## Latest: Phase 15 - Kubernetes Deployment Complete
-
-We've successfully deployed NeuraScale to production with enterprise-grade Kubernetes orchestration:
-
-### Production Kubernetes Infrastructure
-
-- **Google Kubernetes Engine (GKE)** with auto-scaling node pools
-- **Helm charts** for all services with version management
-- **Service mesh** with Istio for traffic management and observability
-- **Auto-scaling** configurations for pods and nodes based on load
-- **Health checks** and self-healing with liveness/readiness probes
-
-### Complete Microservices Architecture
-
-- **Neural Engine API** deployed as scalable microservice
-- **WebSocket servers** with session affinity for real-time streaming
-- **Background workers** for signal processing and ML inference
-- **Message queue** integration with Kafka for event streaming
-- **Distributed caching** with Redis cluster
-
-### High Availability & Reliability
-
-- **Multi-zone deployment** across 3 availability zones
-- **Zero-downtime deployments** with rolling updates
-- **Circuit breakers** and retry logic for fault tolerance
-- **Backup and disaster recovery** with automated snapshots
-- **99.9% uptime SLA** achieved in production
-
-### Monitoring & Observability
-
-- **Prometheus metrics** collection with custom dashboards
-- **Grafana visualizations** for system and business metrics
-- **Distributed tracing** with Jaeger for request flow analysis
-- **Centralized logging** with ELK stack (Elasticsearch, Logstash, Kibana)
-- **Alerting** with PagerDuty integration
-
-### Security Enhancements
-
-- **Network policies** for pod-to-pod communication
-- **TLS encryption** for all internal service communication
-- **Secrets management** with Google Secret Manager
-- **RBAC policies** for Kubernetes access control
-- **Security scanning** with Trivy for container vulnerabilities
-
 ## Platform Overview
 
 ### What is NeuraScale?
@@ -257,23 +213,18 @@ graph TB
     - **Phase 11**: NVIDIA Omniverse Integration
     - **Phase 12**: API Implementation & Enhancement
 
-    #### Infrastructure (Phases 13-15)
+    #### Infrastructure (Phases 13-16)
 
     - **Phase 13**: MCP Server Implementation
     - **Phase 14**: Terraform Infrastructure
     - **Phase 15**: Kubernetes Deployment
+    - **Phase 16**: Docker Containerization Enhancement
   </Tabs.Tab>
 
   <Tabs.Tab>
-    #### Phase 16: Docker Containerization Enhancement
+    #### Currently In Progress
 
-    **Timeline**: Q1 2025
-
-    - Multi-stage optimized builds
-    - Security hardening with minimal base images
-    - Container registry management
-    - Vulnerability scanning integration
-    - Size optimization strategies
+    No phases currently in active development. See upcoming phases for planned work.
   </Tabs.Tab>
 
   <Tabs.Tab>

--- a/docs-nextra/src/content/index.mdx
+++ b/docs-nextra/src/content/index.mdx
@@ -1,14 +1,343 @@
-import { Bleed } from 'nextra/components'
+import { Table } from 'nextra/components'
 
 # Introduction
 
-**Nextra** is a [Next.js](https://nextjs.org) based static site generator.
+Welcome to the official documentation for **NeuraScale**, a comprehensive Brain-Computer Interface (BCI) platform providing real-time neural data acquisition, processing, and analysis with sub-100ms latency.
 
-It supports Markdown and React components ([MDX](/features/mdx)), automatically
-generated [sidebar and anchor links](/get-started#sidebar-and-anchor-links),
-file-system based routing, built-in syntax highlighting, image optimization,
-custom layouts, i18n, and all the features you love about Next.js.
+## Latest: Phase 15 - Kubernetes Deployment Complete
 
-Here's what you will get in 1 minute:
+We've successfully deployed NeuraScale to production with enterprise-grade Kubernetes orchestration:
 
-<Bleed>![Nextra Example](/demo.png)</Bleed>
+### Production Kubernetes Infrastructure
+
+- **Google Kubernetes Engine (GKE)** with auto-scaling node pools
+- **Helm charts** for all services with version management
+- **Service mesh** with Istio for traffic management and observability
+- **Auto-scaling** configurations for pods and nodes based on load
+- **Health checks** and self-healing with liveness/readiness probes
+
+### Complete Microservices Architecture
+
+- **Neural Engine API** deployed as scalable microservice
+- **WebSocket servers** with session affinity for real-time streaming
+- **Background workers** for signal processing and ML inference
+- **Message queue** integration with Kafka for event streaming
+- **Distributed caching** with Redis cluster
+
+### High Availability & Reliability
+
+- **Multi-zone deployment** across 3 availability zones
+- **Zero-downtime deployments** with rolling updates
+- **Circuit breakers** and retry logic for fault tolerance
+- **Backup and disaster recovery** with automated snapshots
+- **99.9% uptime SLA** achieved in production
+
+### Monitoring & Observability
+
+- **Prometheus metrics** collection with custom dashboards
+- **Grafana visualizations** for system and business metrics
+- **Distributed tracing** with Jaeger for request flow analysis
+- **Centralized logging** with ELK stack (Elasticsearch, Logstash, Kibana)
+- **Alerting** with PagerDuty integration
+
+### Security Enhancements
+
+- **Network policies** for pod-to-pod communication
+- **TLS encryption** for all internal service communication
+- **Secrets management** with Google Secret Manager
+- **RBAC policies** for Kubernetes access control
+- **Security scanning** with Trivy for container vulnerabilities
+
+## Platform Overview
+
+### What is NeuraScale?
+
+NeuraScale is a cloud-native BCI platform that enables:
+
+- **Universal Device Support**: 30+ BCI devices from consumer to research grade
+- **Real-Time Processing**: Sub-100ms latency for closed-loop applications
+- **Massive Scalability**: Handle 10,000+ channels simultaneously
+- **Clinical Compliance**: HIPAA/GDPR compliant with end-to-end encryption
+- **ML Integration**: Real-time inference and online learning capabilities
+
+### Core Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│              User Applications                       │
+│    (Research Tools, Clinical Apps, Consumer BCI)    │
+└────────────────────────┬────────────────────────────┘
+                         │
+┌────────────────────────┴────────────────────────────┐
+│                 NeuraScale Platform                  │
+├──────────────────────────────────────────────────────┤
+│  ┌──────────┐  ┌──────────┐  ┌──────────────────┐  │
+│  │  Device  │  │Processing│  │  Data Management │  │
+│  │ Manager  │→ │ Pipeline │→ │   & Storage      │  │
+│  └──────────┘  └──────────┘  └──────────────────┘  │
+│                                                      │
+│  ┌──────────┐  ┌──────────┐  ┌──────────────────┐  │
+│  │WebSocket │  │ REST API │  │Machine Learning  │  │
+│  │ Server   │  │(FastAPI) │  │   Engine         │  │
+│  └──────────┘  └──────────┘  └──────────────────┘  │
+└──────────────────────────────────────────────────────┘
+```
+
+## Documentation Sections
+
+### Getting Started
+
+- **[Quick Start Guide](/getting-started)** - Set up NeuraScale in minutes
+- **[Installation Guide](/docs/installation)** - Detailed setup instructions
+- **[First Recording](/docs/first-recording)** - Record your first neural data
+
+### Neural Engine
+
+- **[Neural Engine Overview](/neural-management-system)** - Core processing system
+- **[Device Integration](/docs/device-integration)** - Connect BCI devices
+- **[Signal Processing](/docs/signal-processing)** - DSP algorithms and filters
+- **[API Reference](/api-documentation)** - Complete API documentation
+
+### Technical Specifications
+
+#### Supported Devices
+
+**Consumer BCIs**
+
+- OpenBCI (Cyton, Ganglion, Cyton+Daisy)
+- Emotiv (EPOC+, Insight)
+- Muse (Muse 2, Muse S)
+- NeuroSky MindWave
+
+**Research Systems**
+
+- g.tec (g.USBamp, g.Nautilus)
+- BrainProducts (actiCHamp, LiveAmp)
+- ANT Neuro (eego™)
+- BioSemi ActiveTwo
+
+**Clinical Arrays**
+
+- Blackrock (Utah Array, CerePlex)
+- Plexon OmniPlex
+- Custom LSL streams
+
+#### Performance Metrics
+
+<Table>
+  <thead>
+    <Table.Tr>
+      <Table.Th>Metric</Table.Th>
+      <Table.Th>Specification</Table.Th>
+    </Table.Tr>
+  </thead>
+  <tbody>
+    <Table.Tr>
+      <Table.Td>Latency</Table.Td>
+      <Table.Td>50-80ms (typical), &lt;100ms (guaranteed)</Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td>Sampling Rates</Table.Td>
+      <Table.Td>Up to 30 kHz (spikes), 1-2 kHz (LFP), 250-500 Hz (EEG)</Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td>Channel Count</Table.Td>
+      <Table.Td>8 to 10,000+ channels</Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td>Data Throughput</Table.Td>
+      <Table.Td>40 MB/s sustained</Table.Td>
+    </Table.Tr>
+    <Table.Tr>
+      <Table.Td>Storage Compression</Table.Td>
+      <Table.Td>10:1 with lossless algorithms</Table.Td>
+    </Table.Tr>
+  </tbody>
+</Table>
+
+### Developer Resources
+
+- **[API Documentation](/api-documentation)** - RESTful and WebSocket APIs
+- **[SDK Reference](/docs/sdk)** - Python, JavaScript, MATLAB clients
+- **[Plugin Development](/docs/plugins)** - Create custom device drivers
+- **[Contributing Guide](/contributing)** - Join the development
+
+### Infrastructure
+
+- **[Architecture Overview](/architecture)** - System design and components
+- **[Architecture Diagrams](/architecture-diagrams)** - Visual system representations
+- **[Deployment Guide](/docs/deployment)** - Production deployment
+- **[Scaling Guide](/docs/scaling)** - Handle enterprise workloads
+- **[Security & Compliance](/security)** - HIPAA/GDPR implementation
+
+### Data Management
+
+- **[Dataset Management](/dataset-management)** - Handle neural datasets
+- **[File Formats](/docs/file-formats)** - EDF+, HDF5, custom binary
+- **[Time Series Storage](/docs/timeseries)** - TimescaleDB optimization
+- **[Data Export](/docs/export)** - Export for analysis
+
+### Machine Learning
+
+- **[ML Pipeline](/docs/ml-pipeline)** - Real-time inference
+- **[Model Training](/docs/training)** - Train BCI decoders
+- **[Online Learning](/docs/online-learning)** - Adaptive classifiers
+- **[Pre-trained Models](/docs/models)** - Ready-to-use models
+
+## Use Cases
+
+### Research Applications
+
+- **Motor Imagery**: Decode movement intentions
+- **P300 Spellers**: Brain-controlled typing
+- **SSVEP**: Steady-state visual stimuli
+- **Neurofeedback**: Real-time brain training
+
+### Clinical Applications
+
+- **Seizure Detection**: Real-time epilepsy monitoring
+- **Sleep Staging**: Automatic sleep analysis
+- **Stroke Rehabilitation**: Motor recovery training
+- **Locked-in Syndrome**: Communication interfaces
+
+### Consumer Applications
+
+- **Meditation Apps**: Track mental states
+- **Gaming**: Mind-controlled games
+- **Productivity**: Focus and attention monitoring
+- **Wellness**: Stress and relaxation tracking
+
+## Platform Status
+
+### Implementation Progress
+
+#### Completed Phases (Foundation & Integration)
+
+- **Phase 1**: Core Infrastructure Setup
+- **Phase 2**: Data Models & Storage Layer
+- **Phase 3**: Basic Signal Processing Pipeline
+- **Phase 4**: User Management & Authentication
+- **Phase 5**: Device Interfaces & LSL Integration
+- **Phase 6**: Clinical Workflow Management
+- **Phase 7**: Advanced Signal Processing
+- **Phase 8**: Real-time Classification & Prediction
+
+#### Completed Phases (Intelligence)
+
+- **Phase 9**: Performance Monitoring & Analytics
+- **Phase 10**: Security & Compliance Layer
+- **Phase 11**: NVIDIA Omniverse Integration
+- **Phase 12**: API Implementation & Enhancement
+
+#### Completed Phases (Infrastructure)
+
+- **Phase 13**: MCP Server Implementation
+- **Phase 14**: Terraform Infrastructure
+- **Phase 15**: Kubernetes Deployment (Current)
+
+#### In Progress
+
+- **Phase 16**: Docker Containerization Enhancement (Q1 2025)
+  - Multi-stage optimized builds
+  - Security hardening
+  - Registry management
+
+#### Upcoming
+
+- **Phase 17**: CI/CD Pipeline (Q1 2025)
+  - GitHub Actions workflows
+  - GitLab CI integration
+  - ArgoCD for GitOps
+
+- **Phase 18-20**: Quality Assurance (Q2 2025)
+  - Unit Testing Suite
+  - Integration Testing
+  - Performance Testing
+
+- **Phase 21-22**: Delivery (Q3 2025)
+  - Documentation & Training
+  - Full System Integration Test
+
+## Quick Start
+
+### Prerequisites
+
+- Python 3.12.11 (exact version required)
+- Node.js 18+ and pnpm 9+
+- Docker & Docker Compose
+- 8GB RAM minimum (16GB recommended)
+
+### Installation
+
+```bash
+# Clone repository
+git clone https://github.com/identity-wael/neurascale.git
+cd neurascale
+
+# Set up virtual environments
+./scripts/dev-tools/setup-venvs.sh
+
+# Start infrastructure
+docker-compose up -d
+
+# Start Neural Engine
+cd neural-engine
+source venv/bin/activate
+python -m src.main
+
+# Start Console (new terminal)
+cd console
+npm run dev
+```
+
+Visit `http://localhost:3000` to access the NeuraScale console.
+
+### Test with Synthetic Device
+
+```bash
+# Create synthetic device
+curl -X POST http://localhost:8000/api/v1/devices \
+  -H "Content-Type: application/json" \
+  -d '{"device_id": "test", "device_type": "synthetic"}'
+
+# Start streaming
+curl -X POST http://localhost:8000/api/v1/devices/test/stream/start
+```
+
+## Community & Support
+
+### Getting Help
+
+- **[Documentation](https://docs.neurascale.io)** - Comprehensive guides
+- **[GitHub Discussions](https://github.com/identity-wael/neurascale/discussions)** - Ask questions
+- **[Issue Tracker](https://github.com/identity-wael/neurascale/issues)** - Report bugs
+- **[Email Support](mailto:support@neurascale.io)** - Direct assistance
+
+### Contributing
+
+We welcome contributions! See our [Contributing Guide](/contributing) for:
+
+- Code style guidelines
+- Development workflow
+- Testing requirements
+- Pull request process
+
+### Roadmap
+
+Track our progress and upcoming features:
+
+- [GitHub Project Board](https://github.com/identity-wael/neurascale/projects/1)
+- [Milestone Tracking](https://github.com/identity-wael/neurascale/milestones)
+- [Release Notes](https://github.com/identity-wael/neurascale/releases)
+
+## License
+
+NeuraScale is open source under the MIT License. See [LICENSE](https://github.com/identity-wael/neurascale/blob/main/LICENSE) for details.
+
+---
+
+**Built by the NeuraScale Team**
+
+_Bridging Mind and World Through Advanced Neural Cloud Technology_
+
+_Last updated: January 27, 2025_

--- a/docs-nextra/src/content/index.mdx
+++ b/docs-nextra/src/content/index.mdx
@@ -62,25 +62,51 @@ NeuraScale is a cloud-native BCI platform that enables:
 
 ### Core Architecture
 
-```
-┌─────────────────────────────────────────────────────┐
-│              User Applications                       │
-│    (Research Tools, Clinical Apps, Consumer BCI)    │
-└────────────────────────┬────────────────────────────┘
-                         │
-┌────────────────────────┴────────────────────────────┐
-│                 NeuraScale Platform                  │
-├──────────────────────────────────────────────────────┤
-│  ┌──────────┐  ┌──────────┐  ┌──────────────────┐  │
-│  │  Device  │  │Processing│  │  Data Management │  │
-│  │ Manager  │→ │ Pipeline │→ │   & Storage      │  │
-│  └──────────┘  └──────────┘  └──────────────────┘  │
-│                                                      │
-│  ┌──────────┐  ┌──────────┐  ┌──────────────────┐  │
-│  │WebSocket │  │ REST API │  │Machine Learning  │  │
-│  │ Server   │  │(FastAPI) │  │   Engine         │  │
-│  └──────────┘  └──────────┘  └──────────────────┘  │
-└──────────────────────────────────────────────────────┘
+```mermaid
+graph TB
+    subgraph "User Applications"
+        A1[Research Tools]
+        A2[Clinical Apps]
+        A3[Consumer BCI]
+    end
+
+    subgraph "NeuraScale Platform"
+        subgraph "Core Components"
+            B1[Device Manager]
+            B2[Processing Pipeline]
+            B3[Data Management & Storage]
+        end
+
+        subgraph "API Layer"
+            C1[WebSocket Server]
+            C2[REST API<br/>FastAPI]
+            C3[Machine Learning Engine]
+        end
+    end
+
+    A1 --> C1
+    A1 --> C2
+    A2 --> C1
+    A2 --> C2
+    A3 --> C1
+    A3 --> C2
+
+    B1 --> B2
+    B2 --> B3
+
+    C1 --> B1
+    C2 --> B1
+    C3 --> B2
+
+    style A1 fill:#1565c0,color:#ffffff
+    style A2 fill:#1565c0,color:#ffffff
+    style A3 fill:#1565c0,color:#ffffff
+    style B1 fill:#e65100,color:#ffffff
+    style B2 fill:#e65100,color:#ffffff
+    style B3 fill:#e65100,color:#ffffff
+    style C1 fill:#6a1b9a,color:#ffffff
+    style C2 fill:#6a1b9a,color:#ffffff
+    style C3 fill:#6a1b9a,color:#ffffff
 ```
 
 ## Documentation Sections

--- a/docs-nextra/src/content/index.mdx
+++ b/docs-nextra/src/content/index.mdx
@@ -254,52 +254,6 @@ graph TB
   </Tabs.Tab>
 </Tabs>
 
-## Quick Start
-
-### Prerequisites
-
-- Python 3.12.11 (exact version required)
-- Node.js 18+ and pnpm 9+
-- Docker & Docker Compose
-- 8GB RAM minimum (16GB recommended)
-
-### Installation
-
-```bash
-# Clone repository
-git clone https://github.com/identity-wael/neurascale.git
-cd neurascale
-
-# Set up virtual environments
-./scripts/dev-tools/setup-venvs.sh
-
-# Start infrastructure
-docker-compose up -d
-
-# Start Neural Engine
-cd neural-engine
-source venv/bin/activate
-python -m src.main
-
-# Start Console (new terminal)
-cd console
-npm run dev
-```
-
-Visit `http://localhost:3000` to access the NeuraScale console.
-
-### Test with Synthetic Device
-
-```bash
-# Create synthetic device
-curl -X POST http://localhost:8000/api/v1/devices \
-  -H "Content-Type: application/json" \
-  -d '{"device_id": "test", "device_type": "synthetic"}'
-
-# Start streaming
-curl -X POST http://localhost:8000/api/v1/devices/test/stream/start
-```
-
 ## Community & Support
 
 ### Getting Help


### PR DESCRIPTION
## Summary

This PR migrates the NeuraScale documentation from docs-site to docs-nextra with a phased approach, implementing professional content and modern Nextra components.

## Changes Made

### 1. Introduction Page Improvements
- Replaced Nextra example content with NeuraScale home page documentation
- Removed all emojis for professional appearance
- Converted markdown table to Nextra Table component for performance metrics
- Replaced ASCII architecture diagram with professional Mermaid.js diagram
- Added dark mode-friendly colors to Mermaid diagram
- Removed redundant Quick Start section (now in dedicated Get Started page)
- Reorganized content flow: Platform Overview now directly follows introduction

### 2. Roadmap Organization
- Implemented Nextra Tabs component for project roadmap
- Created three tabs: Completed, In Progress, and Upcoming
- Organized 22 phases with proper categorization
- Updated Phase 16 status to completed
- Added timeline information and detailed objectives

### 3. Get Started Page
- Replaced generic Nextra example with comprehensive NeuraScale guide
- Implemented Nextra components:
  - Steps for installation flow
  - Tabs for command organization
  - Callouts for warnings and troubleshooting
- Added clear prerequisites with Python 3.12.11 requirement
- Created Next Steps grid with navigation cards
- Added troubleshooting section with common issues

## Technical Details

- All pages build successfully without errors
- Used proper Nextra component imports
- Maintained consistent styling and formatting
- Preserved all links and navigation structure

## Testing

- ✅ Build passes without errors
- ✅ Dev server runs correctly
- ✅ All pages render properly
- ✅ Mermaid diagrams display correctly
- ✅ Tabs and other components function as expected

## Screenshots

The updated documentation provides a professional, clean interface for NeuraScale users with better organization and navigation.

🤖 Generated with [Claude Code](https://claude.ai/code)